### PR TITLE
8 new DM skills (code-verified) + repo-wide format standardization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,23 @@ mcp/                    # hosted Python MCP server — runtime chat only
 ## Skills
 
 - Each skill is a single `SKILL.md` with YAML frontmatter (`name`, `description`) following the format of `skills/iblai-agent-settings/SKILL.md` and `skills/iblai-login/SKILL.md`.
+- **Canonical section structure (every endpoint-documenting skill MUST follow this):**
+  1. `## Auth & conventions` — base URL, header, path vars, prefix, "run `/iblai-login` first" line, and the destructive-confirm note.
+  2. *(optional)* one short explanatory section (e.g. `## Concepts`, `## Pagination`) when the API needs framing before the endpoints.
+  3. `## Reads` — every read endpoint (**GET**/**HEAD**).
+  4. `## Writes` — every write endpoint (**POST**/**PUT**/**PATCH**/**DELETE**); mark each destructive/outward-facing call "Confirm with the user first."
+  5. `## Example` — one realistic `curl`.
+  6. `## Notes` — gotchas.
+  - **Multi-resource skills** (catalog, crm, rbac, billing, …) keep their resource grouping as `###` sub-headings **inside** `## Reads` and `## Writes` (a resource with both appears under each). Do **not** group endpoints by resource at the top level — Reads/Writes is always the top-level split.
+  - A read-only skill may omit `## Writes`; a write-only skill may omit `## Reads`.
+  - Exceptions: non-REST flow skills (`iblai-login`, `iblai-agent-chat`) are setup guides, not endpoint references, and do not use Reads/Writes.
 - **Auth model (every skill):** base URL `https://api.iblai.app`, header `Authorization: Api-Token $IBLAI_API_KEY`. Path vars `{org}` = `$IBLAI_ORG` (a.k.a. `platform_key`), `{username}` = `$IBLAI_USERNAME`, `{mentor}` = the agent's unique id.
+- **Gateway prefixes — `/dm` and `/edx`.** `api.iblai.app` is a gateway that sits **in front of** the backend services and strips a prefix before routing:
+  - `https://api.iblai.app/dm/...` → the **Data Manager** service (the [`iblai/iblai-dm-pro`](https://github.com/iblai/iblai-dm-pro) repo).
+  - `https://api.iblai.app/edx/...` → the **Open edX** service (a different system).
+
+  The prefix is added at the gateway, so it does **not** appear in any backend `urls.py` — the source repos register bare `/api/...` routes. A skill must prepend the right prefix (e.g. a DM route `/api/catalog/courses/` is documented and called as `https://api.iblai.app/dm/api/catalog/courses/`). When in doubt, an endpoint is a **`/dm`** endpoint.
+- **Source of truth = the repo URLconf, not the docs.** Skills for DM features are derived from `iblai-dm-pro`. The app `USAGE.md` files are a starting point but contain errors, gaps, and (critically) endpoints that only apply to **edX** — those do **not** belong here. **Rule: only document an endpoint if it is registered in that repo's `urls.py` (i.e. reachable at `api.iblai.app/dm/...`).** If a path is not in this repo's URL configuration, drop it — it would not resolve via `/dm`. Always verify each endpoint's method, path, and request fields against the actual `urls.py` / views / serializers before shipping a skill.
 - **Connecting an organization:** `/iblai-login` opens `https://login.iblai.app/me`, lets the user pick one of their organizations, and writes `IBLAI_ORG`, `IBLAI_USERNAME`, and `IBLAI_API_KEY` to `.env`. Always ask the user which org to target — accounts can belong to many (40+ is normal).
   - **Logged out:** `/me` redirects to `/login`. Detect this (URL is `/login`, no "My Account" content), hand the user the `https://login.iblai.app/me` URL, and wait for them to sign in — never enter their credentials.
   - **After login the platform redirects somewhere else** (the destination varies and may change), NOT back to `/me`. Don't depend on where it lands — always **re-navigate explicitly to `https://login.iblai.app/me`** before reading params.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ After installing, use these directly in your AI agent with `/` commands.
 /iblai-management       /iblai-crm
 /iblai-integrations     /iblai-notifications
 /iblai-tokens          /iblai-invites
+/iblai-scim            /iblai-billing
+/iblai-features
 ```
 
 ### Profile
@@ -107,7 +109,9 @@ After installing, use these directly in your AI agent with `/` commands.
 
 ```text
 /iblai-search              /iblai-course-create
-/iblai-analytics
+/iblai-analytics           /iblai-catalog
+/iblai-milestones          /iblai-credentials
+/iblai-catalog-media       /iblai-catalog-invitations
 ```
 
 ### What each skill does
@@ -142,11 +146,19 @@ After installing, use these directly in your AI agent with `/` commands.
 | `/iblai-tokens` | Platform API Tokens — list, create (secret shown once), delete |
 | `/iblai-notifications` | Org notifications — counts, inbox, mark-as-read, build & send |
 | `/iblai-invites` | User invitations — list and send (single or CSV bulk) |
+| `/iblai-scim` | SCIM 2.0 directory provisioning — users (Enterprise extension), groups, departments, memberships; RBAC group assignment auto-links platforms |
+| `/iblai-billing` | Billing & credits — credit accounts, item paywalls, prices, checkout (auth + guest), subscriptions, access checks, revenue/subscriber reporting |
+| `/iblai-features` | Per-user feature config & flags — get/update (inline or feature+values), bulk-config, apps/onboarding, trial activation, platform provisioning |
 | `/iblai-profile` | The signed-in user's own profile — Basic, Social, Education, Experience, Resume, Memory |
 | `/iblai-profile-metadata` | Per-user, per-org metadata key-value store — preferences, settings, feature flags |
 | `/iblai-search` | Discover agents and content + personalized (RAG) recommendations — faceted search (read-only) |
 | `/iblai-analytics` | Analytics across agents, content, and users — KPIs, users, topics, transcripts, costs, courses, programs, audit, reports |
 | `/iblai-course-create` | Course Creation API — generate, edit, and publish courses (tasks, outline, structure) |
+| `/iblai-catalog` | Learning catalog — courses, programs, pathways, resources, skills/roles taxonomy, enrollment, eligibility, reviews |
+| `/iblai-milestones` | Catalog milestones — course/resource/program/pathway completions and skill points (block, course, platform, user) |
+| `/iblai-credentials` | Digital credentials — credential CRUD, user/group assignments, assertions, course import/export, provider config (Accredible), analytics |
+| `/iblai-catalog-media` | Catalog media resources — list/create/update/delete media tied to courses/units/items, multipart upload, search, by-item lookup |
+| `/iblai-catalog-invitations` | Catalog invitations & licensing — platform/course/program invitations (bulk, blank, redeem), licenses & assignments, access requests, suggestions |
 
 Skills live in [`skills/`](./skills). Read them, extend them, or write your own.
 

--- a/skills/iblai-agent-embed/SKILL.md
+++ b/skills/iblai-agent-embed/SKILL.md
@@ -29,6 +29,10 @@ Use when embedding an agent on an external website.
 - **GET** `…/mentors/{mentor}/sharable-link` — existing share-link token (404 = none).
 - **GET** `https://learn.iblai.app/ibl-auth/get-provider-slug/?platform_key={org}&username={username}` — SSO providers (LMS host).
 
+### Backend token provisioning
+
+- **GET** `https://api.iblai.app/dm/api/core/users/platforms/` — fetch the user's organization/platform record.
+
 ## Writes
 
 - **PUT** `…/mentors/{mentor}/settings/` — save embed settings (`multipart/form-data`, send only changed keys):
@@ -68,7 +72,7 @@ Use when embedding an agent on an external website.
   }
   ```
 
-## Backend token provisioning (server-to-server embed auth)
+### Backend token provisioning (server-to-server embed auth)
 
 Skip the SSO login popup by minting the user's tokens from your own backend, then
 handing the embed the same `ibl-data` blob the Auth SPA would have produced. All
@@ -76,7 +80,6 @@ calls are **server-to-server** with the org's Platform API Token — never expos
 this in browser JS.
 
 - **POST** `https://api.iblai.app/dm/api/core/consolidated-token/provision/` — resolve-or-create the user and mint `dm_token` + `axd_token`.
-- **GET** `https://api.iblai.app/dm/api/core/users/platforms/` — fetch the user's organization/platform record.
 - Assemble those into the `ibl-data` payload and pass it to the iframe.
 
 Gated per-org by the ibl.ai-managed flag `ENABLE_PLATFORM_CONSOLIDATED_PROXY_PROVISIONING`

--- a/skills/iblai-agent-evals/SKILL.md
+++ b/skills/iblai-agent-evals/SKILL.md
@@ -22,15 +22,31 @@ agent against a dataset and grade the results.
 - Not connected yet? Run **`/iblai-login`** first to populate `IBLAI_ORG`,
   `IBLAI_USERNAME`, and `IBLAI_API_KEY`.
 
-## Datasets
+## Reads
+
+### Datasets
 
 - **GET** `https://api.iblai.app/dm/api/ai-agent/orgs/{org}/users/{username}/evaluations/datasets/` — list.
-- **POST** `…/evaluations/datasets/` — create.
 - **GET** `…/evaluations/datasets/{dataset_name}/` — get one.
 
-## Dataset items
+### Dataset items
 
 - **GET** `…/datasets/{dataset_name}/items/` — list items.
+
+### Experiments (runs)
+
+- **GET** `…/datasets/{dataset_name}/runs/` — list runs.
+- **GET** `…/datasets/{dataset_name}/runs/{run_name}/` — run details.
+- **GET** `…/datasets/{dataset_name}/runs/{run_name}/export/` — export results as CSV.
+
+## Writes
+
+### Datasets
+
+- **POST** `…/evaluations/datasets/` — create.
+
+### Dataset items
+
 - **POST** `…/datasets/{dataset_name}/items/` — add items (direct JSON, or link
   from existing chat traces — the system extracts input + agent response from
   each trace).
@@ -38,15 +54,12 @@ agent against a dataset and grade the results.
 - **PUT** `…/datasets/{dataset_name}/items/{item_id}/` — update an item.
 - **DELETE** `…/datasets/{dataset_name}/items/{item_id}/` — delete an item. Destructive — confirm with the user first.
 
-## Experiments (runs)
+### Experiments (runs)
 
-- **GET** `…/datasets/{dataset_name}/runs/` — list runs.
 - **POST** `…/datasets/{dataset_name}/runs/` — start an experiment (async background task; sends each question to the agent, records responses).
-- **GET** `…/datasets/{dataset_name}/runs/{run_name}/` — run details.
-- **GET** `…/datasets/{dataset_name}/runs/{run_name}/export/` — export results as CSV.
 - **DELETE** `…/datasets/{dataset_name}/runs/{run_name}/` — delete a run. Destructive — confirm with the user first.
 
-## Grading
+### Grading
 
 - **POST** `…/datasets/{dataset_name}/runs/{run_name}/evaluate/` — **LLM-as-Judge**: grade a whole run against custom criteria (score 0–1).
 - **GET** `…/evaluations/scores/` ; **POST** `…/evaluations/scores/` ; **DELETE** `…/evaluations/scores/{score_id}/` — human/numeric/boolean/categorical scores. Deletion is destructive — confirm with the user first.

--- a/skills/iblai-agent-history/SKILL.md
+++ b/skills/iblai-agent-history/SKILL.md
@@ -33,7 +33,9 @@ users have chatted with an agent.
 - **GET** `https://api.iblai.app/dm/api/ai-mentor/orgs/{org}/users/{username}/mentors/{mentor}/summaries/general/` — general summary, average rating, and topics.
 - **GET** `https://api.iblai.app/dm/api/ai-mentor/orgs/{org}/users/{username}/memory/{conversationId}/` — per-conversation memory.
 
-## Writes (Export)
+## Writes
+
+### Export
 
 Export is async — **POST** to create the report, then **GET**-poll until the
 download URL appears.

--- a/skills/iblai-agent-skills/SKILL.md
+++ b/skills/iblai-agent-skills/SKILL.md
@@ -24,7 +24,9 @@ which skills an agent has assigned, and manage the catalog itself (create / edit
 - **GET** `https://api.iblai.app/dm/api/ai-mentor/orgs/{org}/agent-skills/` — platform skill catalog.
 - **GET** `https://api.iblai.app/dm/api/ai-mentor/orgs/{org}/mentors/{mentor}/skills/` — skills assigned to this agent.
 
-## Writes — assignment (toggle)
+## Writes
+
+### Assignment (toggle)
 
 - **POST** `…/mentors/{mentor}/skills/` — assign a skill to the agent:
   ```json
@@ -41,7 +43,7 @@ which skills an agent has assigned, and manage the catalog itself (create / edit
   ```
 - **DELETE** `…/mentors/{mentor}/skills/{assignmentId}/` — unassign the skill (no body).
 
-## Writes — catalog CRUD
+### Catalog CRUD
 
 - **POST** `…/orgs/{org}/agent-skills/` — create a catalog skill:
   ```json

--- a/skills/iblai-analytics/SKILL.md
+++ b/skills/iblai-analytics/SKILL.md
@@ -30,19 +30,21 @@ Reads are read-only; the only writes are Data Reports.
   (plus `&mentor_unique_id={mentor}` when scoping to an agent) is implied as `&…`.
 - Not connected yet? Run **`/iblai-login`** first.
 
-## Reads — Overview / Users / Topics / Transcripts / Costs
+## Reads
+
+### Overview / Users / Topics / Transcripts / Costs
 
 These endpoints serve both **agent** scope and **organization-wide** scope;
 include `mentor_unique_id` for the former, omit it for the latter.
 
-### Overview
+#### Overview
 
 - **GET** `…/analytics/topics/?date_filter=30d&…` — Messages / Topics / Conversations KPIs.
 - **GET** `…/analytics/users/?metric=active_users_last_30d&date_filter=30d&…` — Active Users KPI.
 - **GET** `…/analytics/sessions/?date_filter={r}&…` — Sessions line chart.
 - **GET** `…/analytics/topics/details/?date_filter={r}&…` — Topics bar chart.
 
-### Users
+#### Users
 
 - **GET** `…/analytics/users/?metric=registered_users&date_filter=30d&…`
 - **GET** `…/analytics/users/?metric=active_users&date_filter={r}&…`
@@ -50,20 +52,20 @@ include `mentor_unique_id` for the former, omit it for the latter.
 - **GET** `…/analytics/time/?date_filter={r}&…` — access-time heatmap.
 - **GET** `…/analytics/users/details/?date_filter={r}&page={n}&limit=5&search={q}&…` — user table.
 
-### Topics
+#### Topics
 
 - **GET** `…/analytics/conversations?metric=conversations&date_filter={r}&…`
 - **GET** `…/analytics/topics/?date_filter=30d&…`
 - **GET** `…/analytics/ratings/?date_filter={r}&…`
 - **GET** `…/analytics/topics/details/?date_filter={r}&…`
 
-### Transcripts
+#### Transcripts
 
 - **GET** `…/analytics/conversations?metric=headline&…`
 - **GET** `…/analytics/messages/?search={user}&topic={topic}&page={n}&limit=20&…` — transcript list.
 - **GET** `…/analytics/messages/details/?session_id={id}&…` — one transcript.
 
-### Costs
+#### Costs
 
 - **GET** `…/analytics/financial/?metric=weekly_costs&date_filter=all_time&…`
 - **GET** `…/analytics/financial/?metric=monthly_costs&date_filter=all_time&…`
@@ -73,7 +75,7 @@ include `mentor_unique_id` for the former, omit it for the latter.
 - **GET** `…/analytics/financial/details/?metrics=total_costs,sessions&group_by=username&date_filter={r}&page={n}&limit={l}&search={q}&…`
 - **GET** `…/analytics/financial/details/?metric=total_costs&group_by=llm_model&date_filter={r}&…`
 
-## Reads — Content (Courses & Programs)
+### Content (Courses & Programs)
 
 Course-level and program-level analytics are org-wide catalog breakdowns
 (no `mentor_unique_id`) on the same `…/dm/api/analytics/…` family, keyed
@@ -82,7 +84,7 @@ by course/program — analogous to the `details` grouping used by Costs (e.g.
 the `…/analytics/…/details/` endpoints grouped by course/program, or capture the
 precise sub-path from the live API responses.
 
-## Reads — User analytics
+### User analytics
 
 A single user's own learning data (enrollments, grades, time spent, engagement,
 last access). RBAC-gated (`IsPlatformAdminOfUser | IsSelfAccess`).
@@ -93,16 +95,23 @@ last access). RBAC-gated (`IsPlatformAdminOfUser | IsSelfAccess`).
 (`…/analytics/learners/` and `…/analytics/learner/details` keep the platform's
 wire spelling.)
 
-## Audit
+### Audit
 
 - **GET** `https://api.iblai.app/dm/api/ai-mentor/orgs/{org}/users/{username}/mentors/audit-logs/?limit=20&offset={n}&mentor={mentor}[&action=0|1|2&actor_email=&from_date=&to_date=]`
 
-## Writes (Data Reports)
+### Data Reports
 
 Data Reports (`…/reports`) are the only writes: kick off a report, poll until
 complete, then download the finished CSV from the presigned URL.
 
 - **GET** `…/reports/platforms/{org}/?mentor_id={mentorDbId}` — list reports + status.
+- **GET** `…/reports/platforms/{org}/{report_name}?mentor_unique_id={mentor}` — poll status until complete.
+- **GET** `{status.url}` — download the finished CSV.
+
+## Writes
+
+### Data Reports
+
 - **POST** `…/reports/platforms/{org}/new` — generate a report:
   ```json
   {
@@ -115,8 +124,6 @@ complete, then download the finished CSV from the presigned URL.
     "query": "string"
   }
   ```
-- **GET** `…/reports/platforms/{org}/{report_name}?mentor_unique_id={mentor}` — poll status until complete.
-- **GET** `{status.url}` — download the finished CSV.
 
 ## Example
 

--- a/skills/iblai-billing/SKILL.md
+++ b/skills/iblai-billing/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: iblai-billing
+description: Operate an ibl.ai organization's billing surface via the platform API — credit accounts (balance, auto-recharge, manual top-up), transaction history, generic item paywalls (config + price tiers), Stripe Connect checkout (authenticated and guest), subscriptions, access checks, public pricing, and platform reporting (subscribers, revenue, paywalls). Generic item_type/item_id model: any sellable item (mentor, course, program, pathway, or custom). Use when reading credit balances, configuring an item's paywall and prices, generating a checkout link, checking access, or pulling subscriber/revenue reports.
+---
+
+# iblai-billing
+
+Operate the organization's **billing, credits, and item-paywall** surface from
+the API: credit accounts (display balance, auto-recharge preferences, manual
+top-up), transaction history, per-item paywall configuration and price tiers,
+Stripe-Connect checkout (authenticated + guest), subscriptions, access checks,
+public pricing, and platform-wide reporting. Paywalls are **generic**: every
+endpoint keys off `item_type` + `item_id`, so the same surface sells mentors,
+courses, programs, pathways, or any custom item type. Use when reading a credit
+balance, enabling a paywall and adding prices, generating a checkout link,
+checking whether a user has access, or pulling subscriber/revenue reports.
+
+## Auth & conventions
+
+- **Base URL:** `https://api.iblai.app/dm` — these are Data Manager (DM)
+  endpoints, so the **`/dm` prefix is required**; the `/api/billing/...` paths
+  below are appended to it (e.g.
+  `https://api.iblai.app/dm/api/billing/account/`). Omitting `/dm` will not
+  resolve.
+- **Header:** `Authorization: Api-Token $IBLAI_API_KEY` on every request.
+- **Path vars:** `{platform_key}` = `$IBLAI_ORG` (the org key; also called
+  `org` / `platform_org` elsewhere on the wire). `{item_type}` = the item kind
+  (`mentor`, `course`, `program`, `pathway`, or a custom type — see Notes).
+  `{item_id}` = the item's identifier (e.g. a mentor slug, course id, or
+  `config`/`price` UUID for the by-id variants).
+- DELETE / destructive / outward-facing calls (paywall writes, price create/
+  update/delete, checkout, subscribe, cancel) say "Confirm with the user
+  first."
+- **Permission tiers** vary by endpoint and are noted inline: *authenticated
+  user* (own account), *platform admin / CanSellItems* (paywall config,
+  prices, reporting), and *public / no-auth* (public pricing, guest checkout,
+  Stripe callback). See Notes.
+- Not connected yet? Run **`/iblai-login`** first to populate `IBLAI_ORG`,
+  `IBLAI_USERNAME`, and `IBLAI_API_KEY`.
+
+## Reads
+
+### Credit account & transactions
+
+- **GET** `/api/billing/account/` — current user's credit account info:
+  `has_credits`, `account_id`, `available_credits`, auto-recharge fields,
+  plan info (`current_plan`, `previous_plan`, `free_trial`,
+  `can_use_auto_recharge`), `has_payment_method`, `is_owner`, and
+  `pricing_table`/`message` when applicable. Pass `platform_key` query param to
+  read a **platform** account instead of your own — requires platform admin, a
+  platform API token, or `Ibl.Billing/Credits/read`; plain members get minimal
+  info; non-members are denied.
+- **GET** `/api/billing/transactions/` — paginated transaction history for the
+  account (only user-facing fields: `payment_amount_usd`, `credits_amount`,
+  `credits_balance_after`, `description`). Query params: `platform_key` (omit
+  for own account; read permission enforced), `transaction_type`
+  (`add`|`subtract`|`reserve`|`release`|`rollover`|`refund`),
+  `from_date`/`to_date` (`YYYY-MM-DD`, inclusive), `page`, `page_size`
+  (default 20, max 100).
+
+### Paywall config & prices (platform admin / CanSellItems)
+
+- **GET** `/api/billing/platforms/{platform_key}/items/{item_type}/{item_id}/paywall/`
+  — read the item's paywall config; returns a default disabled config when none
+  exists.
+- **GET** `…/{item_type}/{item_id}/paywall/prices/` — list active price tiers
+  (sorted by `sort_order`, then `amount`).
+- **GET** `…/paywall/prices/{price_id}/` — get one price by its UUID.
+
+### Subscriptions
+
+- **GET** `…/{item_type}/{item_id}/subscription/` — the current user's
+  subscription to this item. `404` if none.
+- **GET** `/api/billing/platforms/{platform_key}/my-subscriptions/` — paginated
+  list of the current user's subscriptions on the platform. Query params:
+  `status` (subscription status — see Notes), `item_type`, `search` (matches
+  `item_id`), `page`, `page_size`.
+
+### Access checks
+
+- **GET** `/api/billing/access-check/{item_type}/{item_id}/` — does the
+  authenticated user have payment access to the item? Returns `200` with
+  `{has_access, item_type, item_id, reason, requires_payment,
+  pricing_available, pricing, subscription}` when access is granted, or
+  **`402` Payment Required** (same body, `has_access:false`, with `pricing`)
+  when payment is needed. Resolves the platform from the `platform_key` query
+  param or request context. Items with no registered paywall backend grant
+  access by default.
+- **GET** `…/{item_type}/{item_id}/access-check/` (platform-scoped) — same
+  check, with `platform_key` taken from the path instead of a query param.
+
+### Public pricing (no auth)
+
+- **GET** `…/{item_type}/{item_id}/pricing/` — **public / no-auth** pricing for
+  an item: `{item_type, item_id, item_name, is_paywalled, allow_free_tier,
+  trial_period_days, prices[]}`. Returns sensible defaults when no paywall
+  config exists.
+- **GET** `/api/billing/items/{config_unique_id}/public-pricing/` —
+  **public / no-auth** variant that resolves the item from the paywall config's
+  UUID, then returns the same payload.
+
+### Checkout (Stripe Connect)
+
+- **GET** `…/{item_type}/{item_id}/checkout-callback/{checkout_session_id}/`
+  and **GET** `…/{item_type}/{item_id}/checkout-callback/` — **public / no-auth**
+  endpoint Stripe redirects to after checkout. Verifies the session, processes
+  completion (creates/updates the subscription, same path as the webhook), and
+  `302`-redirects to the return URL. Session id comes from the path or the
+  `checkout_session_id`/`stripe_checkout_id` query param; `return_url` query
+  param optional. Not called directly — Stripe drives it.
+
+### Platform reporting (platform admin / CanSellItems)
+
+- **GET** `…/{item_type}/{item_id}/subscribers/` — paginated subscribers for one
+  item. Query params: `status` (subscription status), `search` (matches
+  username / email / item_id), `page`, `page_size`.
+- **GET** `/api/billing/platforms/{platform_key}/subscribers/` — paginated
+  subscribers across **all** items on the platform. Query params: `status`,
+  `item_type`, `search`, `page`, `page_size`.
+- **GET** `/api/billing/platforms/{platform_key}/paywalls/` — paginated list of
+  all paywall configs on the platform. Query params: `item_type`, `is_enabled`
+  (boolean), `search` (matches `item_id` / `description`), `page`, `page_size`.
+- **GET** `/api/billing/platforms/{platform_key}/revenue/` — aggregate sales
+  summary across all items: `{sales_volume, sales_count, currency}` (succeeded
+  payments only).
+
+## Writes
+
+### Credit account & transactions
+
+- **PUT** / **PATCH** `/api/billing/account/` — update auto-recharge preferences
+  on your own account (PATCH is identical to PUT). Body fields (all optional):
+  ```json
+  {
+    "auto_recharge_enabled": "boolean",
+    "auto_recharge_threshold_usd": "decimal (>= 0)",
+    "auto_recharge_amount_usd": "decimal (min 0.50)",
+    "auto_recharge_spending_limit_usd": "decimal (0 = unlimited)",
+    "platform_key": "string (read-only in this context)"
+  }
+  ```
+  When enabling, missing values are auto-filled (only-limit → amount = 20% of
+  limit; only-amount → limit = 5× amount; neither → limit 20 / amount 4).
+  Writing to a platform account requires write permission (admin / API token /
+  `Ibl.Billing/Credits/write`).
+- **POST** `/api/billing/auto-recharge/trigger/` — run a charge once.
+  With `amount_usd`: **manual top-up** (charge that amount, add credits; no
+  threshold/limit/cooldown). Without it: run auto-recharge once if enabled and
+  below threshold. Returns `{status: "triggered"|"skipped"}`; `400` if skipped
+  or failed (e.g. no payment method, cooldown, spending-limit exceeded).
+  Confirm with the user first (it charges a card).
+  ```json
+  { "amount_usd": "decimal (optional)", "platform_key": "string (optional, default 'main')" }
+  ```
+
+### Paywall config & prices (platform admin / CanSellItems)
+
+- **POST** / **PUT** `…/{item_type}/{item_id}/paywall/` — create or update the
+  paywall config (PUT is identical to POST). Creates a Stripe product on first
+  enable (requires a payment-ready Stripe Connect account). Confirm with the
+  user first. Body (all optional):
+  ```json
+  {
+    "is_enabled": "boolean",
+    "allow_free_tier": "boolean",
+    "trial_period_days": "integer (>= 0)",
+    "description": "string",
+    "on_successful_payment": "url (<= 500 chars)",
+    "grandfathering_strategy": "free_forever | require_subscription (default require_subscription)",
+    "item_name": "string",
+    "item_metadata": "object"
+  }
+  ```
+- **DELETE** `…/{item_type}/{item_id}/paywall/` — disable the paywall (sets
+  `is_enabled=False`; does **not** delete the config). Returns `204`. Confirm
+  with the user first.
+- **POST** `…/{item_type}/{item_id}/paywall/prices/` — create a price tier.
+  Requires the paywall enabled and a payment-ready Connect account; creates the
+  Stripe price. Returns `201`. Confirm with the user first.
+  ```json
+  {
+    "amount": "decimal (>= 0, required)",
+    "currency": "string (default 'usd')",
+    "interval": "month | year | one_time (default month)",
+    "name": "string", "description": "string",
+    "is_active": "boolean", "features": "object/list",
+    "remark": "string", "sort_order": "integer"
+  }
+  ```
+- **PUT** `…/paywall/prices/{price_id}/` — update a price (partial). If pricing
+  fields (`amount`/`currency`/`interval`) change and a Stripe price exists, a
+  new Stripe price is created and the old one deactivated. Confirm with the
+  user first.
+- **DELETE** `…/paywall/prices/{price_id}/` — soft-delete the price tier and
+  deactivate its Stripe price. Returns `204`. Confirm with the user first.
+
+### Checkout (Stripe Connect)
+
+- **POST** `…/{item_type}/{item_id}/checkout/` — create a Stripe checkout
+  session for the **authenticated** user. Returns
+  `{checkout_url, session_id, platform_key}`. `400` if the user already has an
+  active subscription. Requires a payment-ready Connect account and a Stripe-
+  configured price. Confirm with the user first.
+  ```json
+  { "price_id": "uuid (required)", "success_url": "url", "cancel_url": "url" }
+  ```
+- **POST** `…/{item_type}/{item_id}/checkout-guest/` — **public / no-auth**
+  guest checkout; `email` is required. Same response shape. Confirm with the
+  user first.
+  ```json
+  { "price_id": "uuid (required)", "email": "email (required)", "success_url": "url", "cancel_url": "url" }
+  ```
+- **POST** `/api/billing/prices/{price_unique_id}/checkout-guest/` —
+  **public / no-auth** guest checkout that resolves the platform / item_type /
+  item_id from the price's UUID, then runs the standard guest flow (`email`
+  required; the price's paywall must be enabled). Confirm with the user first.
+
+### Subscriptions
+
+- **POST** `…/{item_type}/{item_id}/subscription/cancel/` — cancel the current
+  user's subscription. For recurring subscriptions returns a Stripe customer-
+  portal URL (`{portal_url}`); for one-time purchases cancels directly and
+  returns the subscription. `404` if none. Confirm with the user first.
+  ```json
+  { "return_url": "url (optional)" }
+  ```
+
+### Credit consumption (sample)
+
+- **POST** `/api/billing/credits/sample-action/` — sample endpoint protected by
+  the `@consume_credits` decorator (authenticated). Checks balance first: if
+  insufficient, returns **`402`** with a `pricing_table`; otherwise runs and
+  consumes 1 credit, returning `{status, message, ...balance}`. This is a
+  reference/test endpoint demonstrating the credit-gating pattern, not a
+  production action.
+
+## Example
+
+Enable a paywall on a course-type item and read its public pricing (note the
+`/dm` prefix). Confirm the paywall write with the user first:
+
+```bash
+curl -X POST \
+  "https://api.iblai.app/dm/api/billing/platforms/$IBLAI_ORG/items/course/course-v1:ACME+CS101+2024/paywall/" \
+  -H "Authorization: Api-Token $IBLAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"is_enabled": true, "trial_period_days": 7, "allow_free_tier": true}'
+```
+
+## Notes
+
+- **item_type values.** Built-in types are `mentor`, `course`, `program`, and
+  `pathway`. Any other value is normalized to a `custom:<slug>` namespace
+  (e.g. `workshop` → `custom:workshop`); the type must start with a letter
+  after slugification or the request `400`s. Do not treat this as a
+  mentor-only paywall — it is the generic item-paywall surface for any sellable
+  item.
+- **Stripe Connect is required** for monetary operations. Enabling a paywall,
+  creating/updating prices, and checkout all need the platform's Stripe Connect
+  account to exist and be payment-ready; otherwise you get a `400`/validation
+  error. Checkout returns a Stripe-hosted `checkout_url`; cancellation of a
+  recurring subscription returns a Stripe customer-portal URL.
+- **402 Payment Required** is meaningful: `GET access-check/...` returns `402`
+  (not `403`) when the user lacks access and must pay, and the
+  `@consume_credits`-gated sample endpoint returns `402` with a `pricing_table`
+  when the balance is too low.
+- **Permission tiers.**
+  - *Authenticated user* (own data): `account/`, `auto-recharge/trigger/`,
+    `transactions/`, `access-check/...`, `subscription/`, `subscription/cancel/`,
+    `my-subscriptions/`, `checkout/`, `credits/sample-action/`. Reading/writing
+    another (platform) credit account additionally requires admin / platform API
+    token / `Ibl.Billing/Credits/read|write`.
+  - *Platform admin + CanSellItems*: all paywall config + price endpoints and
+    the platform reporting endpoints (`subscribers/`, `paywalls/`, `revenue/`).
+    These enforce `IsPlatformAdmin` and the `Ibl.Billing/CanSellItems/action`
+    RBAC policy (when RBAC is enabled) or a matching platform API key.
+  - *Public / no-auth*: `pricing/`, `items/{config_unique_id}/public-pricing/`,
+    `checkout-guest/` (both variants), and `checkout-callback/` (Stripe
+    redirect). These explicitly allow unauthenticated access.
+- **Subscription status** values used as the `status` filter / in responses:
+  `active`, `free`, `grandfathered`, `trialing`, `past_due`, `canceled`,
+  `incomplete`.
+- **Price `interval`** values: `month`, `year`, `one_time`. `one_time` prices
+  checkout in Stripe `payment` mode; recurring prices use `subscription` mode
+  and honor `trial_period_days`.
+- **Async / webhooks.** Checkout completion is processed both via the
+  `checkout-callback/` redirect and via Stripe webhooks (the same handler), so a
+  subscription may be created without your code polling. The callback enriches
+  its return URL with `email`, `platform_key`, and `subscription_id`.
+- **Pagination.** `transactions/` uses page-number pagination (default
+  `page_size` 20, max 100); the reporting/list endpoints (`subscribers/`,
+  platform `subscribers/`, `paywalls/`, `my-subscriptions/`) use the standard
+  page-number paginator. Internal USD amounts are never exposed in transaction
+  history — only the user-facing payment/credit fields.

--- a/skills/iblai-catalog-invitations/SKILL.md
+++ b/skills/iblai-catalog-invitations/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: iblai-catalog-invitations
+description: Manage an ibl.ai organization's catalog invitations, licenses, access requests, and content suggestions via the platform API — platform/course/program invitations (single, bulk, blank, redeem, check); platform/user/course/program licenses (create/update) with per-user and per-group assignments; course/program access requests (request + approve/reject); and course/program/pathway suggestions (per-user, manage, bulk, group). These are the Data Manager (DM) "catalog invitations" REST endpoints, the entitlement/onboarding layer that sits on top of the catalog. Use when inviting users to a platform/course/program, issuing or assigning license seats, reviewing access requests, or pushing course/program/pathway suggestions.
+---
+
+# iblai-catalog-invitations
+
+Manage an organization's **catalog invitations, licenses, access requests, and
+content suggestions** from the API. This is the Data Manager (DM)
+`dl_catalog_invitations` app — the entitlement and onboarding layer on top of
+the catalog (`/iblai-catalog`):
+
+- **Invitations** — invite users (or generate redeemable "blank" invites) to a
+  platform, a course, or a program; single, bulk, blank, redeem, and check.
+- **Licenses** — create/update seat pools (platform / user / course / program
+  licenses) and **assign** them to individual users or to user groups.
+- **Access requests** — let members request course (or program) access and let
+  admins approve/reject them.
+- **Suggestions** — push course, program, or pathway suggestions to a user or a
+  user group (single, bulk, group).
+
+Use when inviting users, issuing or assigning license seats, reviewing access
+requests, or suggesting content.
+
+## Auth & conventions
+
+- **Base URL:** `https://api.iblai.app/dm` — these are Data Manager (DM)
+  endpoints, so the **`/dm` prefix is required**; the `/api/catalog/...` paths
+  below are appended to it (e.g.
+  `https://api.iblai.app/dm/api/catalog/invitations/platform/`). `/dm` is the
+  gateway prefix and is **not** part of the app's own route table.
+- **Header:** `Authorization: Api-Token $IBLAI_API_KEY` on every request
+  (except the two public **check** endpoints, which take no auth).
+- **Path vars:** none — every resource is selected by **query param** (GET /
+  DELETE) or **body field** (POST). `{org}` = `$IBLAI_ORG` appears on the wire
+  as `org` / `platform_key` / `key` / `platform_org` (all mean the org key);
+  `course_id` (opaque-keys form, URL-encode in query strings) and `program_key`
+  (e.g. `org+program-id`) identify catalog items.
+- **Permission tiers** (enforced per view): `IsDMAdmin` = DM admin; `Is(DM|Platform)Admin`
+  = platform admins or DM admins; `IsPlatformAdminReadOnly` = read-only for
+  platform admins; `IsPlatformMember` = any platform member; `IsEdxUserReadOnly`
+  / `IsDepartmentModeAdminInPlatform` widen suggestion access. **License
+  create/update is DM-admin only.** When RBAC is enabled, invitation calls also
+  require the matching `Ibl.Catalog/{Platform|Course|Program}Invitations/`
+  permission for the target platform.
+- DELETE / destructive / outward-facing calls (invite send, bulk invite, redeem,
+  license assign/unassign, access-request approve) say "Confirm with the user
+  first."
+- Not connected yet? Run **`/iblai-login`** first to populate `IBLAI_ORG`,
+  `IBLAI_USERNAME`, and `IBLAI_API_KEY`.
+
+## Reads
+
+### Platform invitations
+
+`Is(DM|Platform)Admin` (the **check** endpoint is public). Invitation `to_json()`
+returns `{id, user_id, username, email, created, started, source, redirect_to, expired, active, metadata, platform_key}`.
+
+- **GET** `/api/catalog/invitations/platform/` — paginated list; filter by `platform_key`, `org`, `email`, `source`, `active`, `sort` (default `-id`); any other param becomes a `metadata__<key>` filter. (RBAC: `platform_key` required when RBAC is on.)
+- **GET** `/api/catalog/invitations/platform/check/` — **public, no auth**; `email` (required, query). `200` if an active platform invitation exists, `404` if not.
+
+### Course invitations
+
+`IsDMAdmin | IsPlatformAdminReadOnly | IsPlatformAdminForCourse` on list/create;
+`IsDMAdmin | IsPlatformAdminForCourse` on blank/redeem. Result `to_json()` carries `course_id` instead of `platform_key`.
+
+- **GET** `/api/catalog/invitations/course/` — paginated list; filter by `course_id`, `email`, `source`, `active`, `platform_key`/`key`, `org`/`platform_org`, `sort` (default `-id`); other params → `metadata__<key>`.
+
+### Program invitations
+
+`IsDMAdmin | IsPlatformAdminReadOnly | IsPlatformAdminForProgram` on list/create;
+`IsDMAdmin | IsPlatformAdminForProgram` on blank/redeem (bulk is `Is(DM|Platform)Admin`). Result `to_json()` carries `program_key`.
+
+- **GET** `/api/catalog/invitations/program/` — paginated list; filter by `program_key`, `program_id`, `email`, `source`, `active`, `platform_key`/`key`, `org`/`platform_org`, `sort` (default `-id`); other params → `metadata__<key>`.
+
+### Platform licenses
+
+Seat pools at the platform level. **GET** is `IsDMAdmin | IsPlatformAdminReadOnly`; **create/update are `IsDMAdmin` only.** License `to_json()` returns `{id, created, started, expired, name, count, active, metadata, source, external_id, platform_key}`.
+
+- **GET** `/api/catalog/licenses/platform/` — paginated list; filter by `platform_key`/`key`, `name`, `source`, `active`, `query` (name icontains), `sort` (default `-id`); other params → `metadata__<key>`.
+
+### User licenses
+
+Platform-level seat pools assignable to specific users/groups. **GET** is `IsDMAdmin | IsPlatformAdminReadOnly`; **create/update `IsDMAdmin` only**; **assignments `Is(DM|Platform)Admin`** (the assignment **check** is public).
+
+- **GET** `/api/catalog/licenses/user/` — paginated list; same filters as platform licenses. Each result embeds an `assignments` summary `{total, active, pending}`.
+- **GET** `/api/catalog/licenses/user/assignment/` — paginated per-user assignments; **`license_id` required**, plus `platform_key`/`platform_org` (required when multitenancy is on), `sort` (default `id`).
+- **GET** `/api/catalog/licenses/user/assignment/group/` — paginated per-group assignments; **`license_id` required**, plus platform params, `sort`.
+- **GET** `/api/catalog/licenses/user/assignment/check/` — **public, no auth**; `email` (required, query). `200` if an active user-license assignment exists, `404` if not.
+
+### Course licenses
+
+Seat pools tied to a course. **GET** `IsDMAdmin | IsPlatformAdminReadOnly`; **create/update `IsDMAdmin` only**; **assignments `Is(DM|Platform)Admin`**. License `to_json()` adds `course_id`.
+
+- **GET** `/api/catalog/licenses/course/` — paginated list; filter by `platform_key`/`key`, `course_id`, `name`, `source`, `active`, `query`, `sort` (default `-id`); other params → `metadata__<key>`.
+- **GET** `/api/catalog/licenses/course/assignment/` — paginated per-user assignments; **`license_id` required**, platform params, `sort` (default `id`).
+- **GET** `/api/catalog/licenses/course/assignment/group/` — paginated per-group assignments; **`license_id` required**, platform params, `sort`.
+
+### Program licenses
+
+Seat pools tied to a program. Permissions identical to course licenses; result `to_json()` adds `program_id`/`program_key`.
+
+- **GET** `/api/catalog/licenses/program/` — paginated list; filter by `platform_key`/`key`, `program_id`, `name`, `source`, `active`, `query`, `sort` (default `-id`); other params → `metadata__<key>`. Each result embeds an `assignments` summary.
+- **GET** `/api/catalog/licenses/program/assignment/` — paginated per-user assignments; **`license_id` required**, platform params, `sort` (default `id`).
+- **GET** `/api/catalog/licenses/program/assignment/group/` — paginated per-group assignments; **`license_id` required**, platform params, `sort`.
+
+### Access requests (course)
+
+Members request access to a course; admins review. The **user** endpoint is
+`IsPlatformMember`; the **manage** endpoint is `Is(DM|Platform)Admin`. Request
+`to_json()` returns `{id, user_id, username, name, approved, reviewed, created, modified, metadata, platform_key, course_id}`.
+
+- **GET** `/api/catalog/access_requests/course/request/` — check the signed-in user's request status for a course; **`course_id` required** (query), plus `platform_key`/`platform_org`. Returns `{active, approved, exists}`.
+- **GET** `/api/catalog/access_requests/course/manage/` — admin: paginated list of access requests; **`platform_key` or `platform_org` required**, plus `reviewed` (filter), `sort` (default `-id`).
+
+> Note: `urls.py` registers **only the course** access-request routes
+> (`course/request`, `course/manage`). There are no program/pathway
+> access-request endpoints in this app.
+
+### Suggestions (course / program / pathway)
+
+Push catalog suggestions to users or groups. The **user** (read) endpoint is
+`IsDMAdmin | IsPlatformAdminReadOnly | IsEdxUserReadOnly`; **manage / bulk /
+group** are `IsDMAdmin | IsPlatformAdmin | IsDepartmentModeAdminInPlatform`. The
+three resource families (course, program, pathway) are structurally identical;
+only the item identifier differs: **course →** `course_id`, **program →**
+`program_key`, **pathway →** `pathway_id`.
+
+#### Course suggestions
+
+- **GET** `/api/catalog/suggestions/course/user/` — a user's suggestions; **`user` required** (username or id, query), plus `platform_key`/`platform_org`, `sort` (default `-id`), `page`, `page_size`.
+- **GET** `/api/catalog/suggestions/course/manage/` — admin: platform suggestions; **`platform_key` or `platform_org` required**, plus `query`, `sort` (default `-id`), `department_mode`, `page`, `page_size`.
+- **GET** `/api/catalog/suggestions/course/manage/group/` — admin: group suggestions; **`platform_key` or `platform_org` required**, plus `query`, `sort` (default `id`), `department_mode`, `page`, `page_size`.
+
+#### Program suggestions
+
+Same shapes; the item field is **`program_key`** (instead of `course_id`).
+
+- **GET** `/api/catalog/suggestions/program/user/` — a user's program suggestions (`user` required).
+- **GET** `/api/catalog/suggestions/program/manage/` — admin list (`platform_key`/`platform_org` required).
+- **GET** `/api/catalog/suggestions/program/manage/group/` — admin group list.
+
+#### Pathway suggestions
+
+Same shapes; the item field is **`pathway_id`**.
+
+- **GET** `/api/catalog/suggestions/pathway/user/` — a user's pathway suggestions (`user` required).
+- **GET** `/api/catalog/suggestions/pathway/manage/` — admin list (`platform_key`/`platform_org` required).
+- **GET** `/api/catalog/suggestions/pathway/manage/group/` — admin group list.
+
+## Writes
+
+### Platform invitations
+
+- **POST** `/api/catalog/invitations/platform/` — create/update one invitation. **Confirm with the user first** (outward-facing). `{ "platform_key": "str (required)", "email": "str (required)", "active": "bool", ...metadata }`.
+- **POST** `/api/catalog/invitations/platform/bulk/` — bulk-create. **Confirm with the user first.** `{ "platform_key": "str (required)", "invitation_data": [{ "platform_key": "...", "email": "...", "active": "bool", ...metadata }] }`. All items must belong to `platform_key`. Returns `{successes, error_codes}`.
+- **POST** `/api/catalog/invitations/platform/blank/` — create N redeemable blank invitations (no user yet). **Confirm with the user first.** `{ "platform_key": "str (required)", "source": "str (required)", "count": "int (required)", ...metadata }`. Returns `{successes, error_codes}`.
+- **POST** `/api/catalog/invitations/platform/redeem/` — redeem a blank invitation onto a user. **Confirm with the user first.** `{ "platform_key": "str (required)", "source": "str (required)", "email": "str", "username": "str", ...metadata }`.
+
+### Course invitations
+
+- **POST** `/api/catalog/invitations/course/` — create/update one invitation (`404` if course unknown). **Confirm with the user first.** `{ "course_id": "str (required)", "email": "str (required)", "active": "bool", ...metadata }`.
+- **POST** `/api/catalog/invitations/course/bulk/` — bulk-create. **Confirm with the user first.** `{ "invitation_data": [{ "course_id": "...", "email": "...", "active": "bool", ...metadata }], "platform_key": "str (optional; inferred from first course if omitted)" }`. All courses must share one platform. Returns `{successes, error_codes}`.
+- **POST** `/api/catalog/invitations/course/blank/` — create N blank course invitations. **Confirm with the user first.** `{ "course_id": "str (required)", "source": "str (required)", "count": "int (required)", ...metadata }`. Returns `{successes, error_codes}`.
+- **POST** `/api/catalog/invitations/course/redeem/` — redeem a blank course invitation. **Confirm with the user first.** `{ "course_id": "str (required)", "source": "str (required)", "email": "str", "username": "str", ...metadata }`.
+
+### Program invitations
+
+- **POST** `/api/catalog/invitations/program/` — create/update one invitation (`404` if program unknown). **Confirm with the user first.** `{ "program_key": "str (required)", "email": "str (required)", "active": "bool", ...metadata }`.
+- **POST** `/api/catalog/invitations/program/bulk/` — bulk-create. **Confirm with the user first.** `{ "invitation_data": [{ "program_key": "...", "email": "...", "active": "bool", ...metadata }], "platform_key": "str (optional; inferred from first program)" }`. All programs must share one platform. Returns `{successes, error_codes}`.
+- **POST** `/api/catalog/invitations/program/blank/` — create N blank program invitations. **Confirm with the user first.** `{ "program_key": "str (required)", "source": "str (required)", "count": "int (required)", ...metadata }`. Returns `{successes, error_codes}`.
+- **POST** `/api/catalog/invitations/program/redeem/` — redeem a blank program invitation. **Confirm with the user first.** `{ "program_key": "str (required)", "source": "str (required)", "email": "str", "username": "str", ...metadata }`.
+
+### Platform licenses
+
+- **POST** `/api/catalog/licenses/platform/create/` — create a license. `{ "platform_key": "str (required)", "name": "str", "count": "int (default 0)", "started": "datetime", "expired": "datetime", "active": "bool (default true)", "metadata": {}, "source": "str", "external_id": "str (unique)" }`.
+- **POST** `/api/catalog/licenses/platform/update/` — update a license; identify by `license_id` **or** `external_id`. `{ "license_id": "int", "external_id": "str", "name": "str", "count": "int", "started": "datetime", "expired": "datetime", "active": "bool", "metadata": {}, "source": "str", "change_type": "str (default 'update')" }`. The platform cannot be changed; each update writes a history record.
+
+### User licenses
+
+- **POST** `/api/catalog/licenses/user/create/` — create. Same body as platform create plus optional `enrollment_config` (dict). `platform_key` required.
+- **POST** `/api/catalog/licenses/user/update/` — update; identify by `license_id` or `external_id`; same fields as platform update plus `enrollment_config`.
+- **POST** `/api/catalog/licenses/user/assignment/` — assign/update a seat for one user. **Confirm with the user first.** `{ "license_id": "int (required)", "user_id": "int", "email": "str", "platform_key": "str", "platform_org": "str", "active": "bool", "fulfilled": "bool", "metadata": {} }` (one of `user_id`/`email` required).
+- **DELETE** `/api/catalog/licenses/user/assignment/` — unassign one seat; **`assignment_id` required** (query), optional `platform_key`/`platform_org`. Confirm with the user first.
+- **POST** `/api/catalog/licenses/user/assignment/group/` — assign/update a seat for a user group. **Confirm with the user first.** `{ "license_id": "int (required)", "group_id": "int (required)", "platform_key": "str", "platform_org": "str", "active": "bool", "fulfilled": "bool", "metadata": {} }`.
+- **DELETE** `/api/catalog/licenses/user/assignment/group/` — unassign a group seat; **`assignment_id` required** (query). Confirm with the user first.
+
+### Course licenses
+
+- **POST** `/api/catalog/licenses/course/create/` — create. `{ "platform_key": "str (required)", "course_id": "str (required)", "name": "str", "count": "int", "started": "datetime", "expired": "datetime", "active": "bool", "metadata": {}, "enrollment_config": {}, "source": "str", "external_id": "str" }`.
+- **POST** `/api/catalog/licenses/course/update/` — update; identify by `license_id` or `external_id`; same updatable fields as user-license update (platform/course immutable).
+- **POST** `/api/catalog/licenses/course/assignment/` — assign/update a course seat to a user. **Confirm with the user first.** `{ "license_id": "int (required)", "user_id": "int" | "email": "str", "platform_key": "str", "platform_org": "str", "active": "bool", "fulfilled": "bool", "metadata": {} }`.
+- **DELETE** `/api/catalog/licenses/course/assignment/` — unassign one course seat; **`assignment_id` required** (query). Confirm with the user first.
+- **POST** `/api/catalog/licenses/course/assignment/group/` — assign/update a course seat to a group. **Confirm with the user first.** `{ "license_id": "int (required)", "group_id": "int (required)", "platform_key": "str", "platform_org": "str", "active": "bool", "fulfilled": "bool", "metadata": {} }`.
+- **DELETE** `/api/catalog/licenses/course/assignment/group/` — unassign a group course seat; **`assignment_id` required** (query). Confirm with the user first.
+
+### Program licenses
+
+- **POST** `/api/catalog/licenses/program/create/` — create. `{ "platform_key": "str (required)", "program_id": "str (required)", "name": "str", "count": "int", "started": "datetime", "expired": "datetime", "active": "bool", "metadata": {}, "enrollment_config": {}, "source": "str", "external_id": "str" }`.
+- **POST** `/api/catalog/licenses/program/update/` — update; identify by `license_id` or `external_id`; same updatable fields (platform/program immutable).
+- **POST** `/api/catalog/licenses/program/assignment/` — assign/update a program seat to a user. **Confirm with the user first.** `{ "license_id": "int (required)", "user_id": "int" | "email": "str", "platform_key": "str", "platform_org": "str", "active": "bool", "fulfilled": "bool", "metadata": {} }`.
+- **DELETE** `/api/catalog/licenses/program/assignment/` — unassign one program seat; **`assignment_id` required** (query). Confirm with the user first.
+- **POST** `/api/catalog/licenses/program/assignment/group/` — assign/update a program seat to a group. **Confirm with the user first.** `{ "license_id": "int (required)", "group_id": "int (required)", "platform_key": "str", "platform_org": "str", "active": "bool", "fulfilled": "bool", "metadata": {} }`.
+- **DELETE** `/api/catalog/licenses/program/assignment/group/` — unassign a group program seat; **`assignment_id` required** (query). Confirm with the user first.
+
+### Access requests (course)
+
+- **POST** `/api/catalog/access_requests/course/request/` — create an access request as the signed-in user. `{ "course_id": "str (required)", "platform_key": "str", "platform_org": "str", ...metadata }`.
+- **POST** `/api/catalog/access_requests/course/manage/` — admin: approve/reject a request. **Confirm with the user first** (approving grants access). `{ "request_id": "int (required)", "approved": "bool", "active": "bool", "platform_key": "str", "platform_org": "str" }`.
+
+### Suggestions (course / program / pathway)
+
+#### Course suggestions
+
+- **POST** `/api/catalog/suggestions/course/manage/` — create/update a per-user suggestion (`201` created, `200` updated). `{ "platform_key": "str (required)", "course_id": "str (required)", "user_id": "str|int (required)", "accepted": "bool", "visible": "bool", "metadata": {} }`.
+- **DELETE** `/api/catalog/suggestions/course/manage/` — delete a suggestion; **`suggestion_id` required** (query). Confirm with the user first.
+- **POST** `/api/catalog/suggestions/course/manage/bulk/` — bulk-create. `{ "platform_key": "str (required)", "suggestion_data": [{ "course_id": "...", "user_id": "...", "accepted": "bool", "visible": "bool", "metadata": {} }] }`. Returns `{successes, error_codes}`.
+- **POST** `/api/catalog/suggestions/course/manage/group/` — create/update a group suggestion. `{ "platform_key": "str (required)", "course_id": "str (required)", "group_id": "str|int (required)", "accepted": "bool", "visible": "bool", "metadata": {} }`.
+- **DELETE** `/api/catalog/suggestions/course/manage/group/` — delete a group suggestion; **`suggestion_id` required** (query). Confirm with the user first.
+
+#### Program suggestions
+
+Same shapes; the item field is **`program_key`** (instead of `course_id`).
+
+- **POST** `/api/catalog/suggestions/program/manage/` — create/update per-user: `{ "platform_key": "...", "program_key": "...", "user_id": "...", "accepted": "bool", "visible": "bool", "metadata": {} }`.
+- **DELETE** `/api/catalog/suggestions/program/manage/` — delete by `suggestion_id` (query). Confirm with the user first.
+- **POST** `/api/catalog/suggestions/program/manage/bulk/` — bulk; `{ "platform_key": "...", "suggestion_data": [{ "program_key": "...", "user_id": "...", ... }] }`.
+- **POST** `/api/catalog/suggestions/program/manage/group/` — create/update group: `{ "platform_key": "...", "program_key": "...", "group_id": "...", ... }`.
+- **DELETE** `/api/catalog/suggestions/program/manage/group/` — delete group suggestion by `suggestion_id` (query). Confirm with the user first.
+
+#### Pathway suggestions
+
+Same shapes; the item field is **`pathway_id`**.
+
+- **POST** `/api/catalog/suggestions/pathway/manage/` — create/update per-user: `{ "platform_key": "...", "pathway_id": "...", "user_id": "...", "accepted": "bool", "visible": "bool", "metadata": {} }`.
+- **DELETE** `/api/catalog/suggestions/pathway/manage/` — delete by `suggestion_id` (query). Confirm with the user first.
+- **POST** `/api/catalog/suggestions/pathway/manage/bulk/` — bulk; `{ "platform_key": "...", "suggestion_data": [{ "pathway_id": "...", "user_id": "...", ... }] }`.
+- **POST** `/api/catalog/suggestions/pathway/manage/group/` — create/update group: `{ "platform_key": "...", "pathway_id": "...", "group_id": "...", ... }`.
+- **DELETE** `/api/catalog/suggestions/pathway/manage/group/` — delete group suggestion by `suggestion_id` (query). Confirm with the user first.
+
+## Example
+
+Assign one user-license seat to a user by email (outward-facing — confirm first):
+
+```bash
+curl -X POST \
+  "https://api.iblai.app/dm/api/catalog/licenses/user/assignment/" \
+  -H "Authorization: Api-Token $IBLAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "license_id": 789,
+        "email": "newhire@example.com",
+        "platform_key": "'"$IBLAI_ORG"'",
+        "active": true
+      }'
+```
+
+## Notes
+
+- **All endpoints are DM endpoints** under `https://api.iblai.app/dm`
+  (`/dm` + `/api/catalog/...`); omitting `/dm` will not resolve.
+- **No path parameters.** Select every resource by query param (GET/DELETE) or
+  body field (POST). License/assignment IDs are integers (`license_id`,
+  `assignment_id`, `suggestion_id`, `request_id`); identify a license to update
+  by `license_id` **or** `external_id`.
+- **Bulk and blank/redeem operations are write-heavy and user-facing** — bulk
+  invites send to every listed email, blank invites create redeemable codes,
+  redeem associates a code with a real user. Treat all of them, plus every
+  license assign/unassign and every access-request approval, as actions to
+  **confirm with the user first**.
+- **Bulk invitations must stay within one platform** — the server rejects
+  (`400`) any item whose course/program/platform differs from the request's
+  `platform_key`.
+- **Org on the wire** appears as `org`, `platform_key`, `key`, or
+  `platform_org` (all the org key). When multitenancy is enabled, license- and
+  assignment-related GETs **require** a `platform_key`/`platform_org`.
+- **Pagination envelope** is the standard `{count, next, previous, results[]}`
+  for every list endpoint here (invitations, licenses, assignments, access
+  requests, suggestions); `sort` defaults to `-id` on most lists but `id` on the
+  assignment and group-suggestion lists.
+- **Public, unauthenticated** endpoints: `invitations/platform/check/` and
+  `licenses/user/assignment/check/` — both take only `email` and answer `200`
+  (exists) / `404` (none).
+- **RBAC gating on invitations.** When `rbac_enabled()`, invitation calls
+  additionally enforce `Ibl.Catalog/{Platform|Course|Program}Invitations/`
+  permission for the target platform (and platform invitation GET then requires
+  `platform_key`); a missing permission returns `403`.
+- **DELETE on the invitation collection endpoints is a stub.** The `delete()`
+  handlers on `invitations/platform/`, `invitations/course/`, and
+  `invitations/program/` are unimplemented (return `200` without deleting) — they
+  are not usable for removing invitations, so they are not listed above.

--- a/skills/iblai-catalog-media/SKILL.md
+++ b/skills/iblai-catalog-media/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: iblai-catalog-media
+description: Manage an ibl.ai organization's catalog media resources via the Data Manager API — videos, images, documents, audio, and external links attached to a course, unit, or resource (item). Per-org, per-user CRUD plus search and by-item lookup, with multipart file upload. Use when attaching media to course/unit/resource content, listing or searching an org's media, or wiring media into catalog items.
+---
+
+# iblai-catalog-media
+
+Manage an organization's **catalog media resources** from the API: media files
+and external links (videos, images, documents, audio, other) attached to a
+course, a unit, a specific resource item, or any combination of the three.
+Supports listing/filtering, full CRUD, a search action, and a by-item lookup.
+The `item_type` (which catalog level the media is associated with) is derived
+automatically from which of `course_id` / `unit_id` / `item_id` you supply.
+Use when attaching media to catalog content, browsing/searching an org's media,
+or uploading media files.
+
+## Auth & conventions
+
+- **Base URL:** `https://api.iblai.app/dm` — these are Data Manager (DM)
+  endpoints, so the **`/dm` prefix is required**; the
+  `/api/media/orgs/{org}/users/{user_id}/media/media-resources/...` paths below
+  are appended to it (e.g.
+  `https://api.iblai.app/dm/api/media/orgs/enterprise/users/36/media/media-resources/`).
+- **Header:** `Authorization: Api-Token $IBLAI_API_KEY` on every request.
+- **Path vars:** `{org}` = `$IBLAI_ORG` (the org key — matched against the
+  platform's `org`), `{user_id}` = the **numeric** user id (matched against
+  `User.id`; this is not the username). Both org and user are baked **into the
+  path** here (unlike most catalog endpoints, which pass them as params).
+- **Auth classes:** session, OAuth2 client-credential, and platform Api-Token.
+- DELETE / destructive / outward-facing calls (delete, file upload) say
+  "Confirm with the user first."
+- Not connected yet? Run **`/iblai-login`** first to populate `IBLAI_ORG`,
+  `IBLAI_USERNAME`, and `IBLAI_API_KEY`. (`user_id` is the numeric id, not the
+  username `IBLAI_USERNAME`.)
+
+All routes are under
+`/api/media/orgs/{org}/users/{user_id}/media/media-resources/`.
+
+## Reads
+
+### Media resources (CRUD)
+
+- **GET** `…/media-resources/` — list media resources for the org's platform
+  (paginated, newest-first). Filters (query params, mutually exclusive in this
+  precedence): `search` (icontains across `title`, `description`, `course_id`,
+  `unit_id`, `item_id`, `file_url`), else `course_id` + `unit_id`, else
+  `course_id`, else `unit_id`, else `item_id`. The id filters also pull in
+  rows whose `item_type` spans that level (e.g. filtering by `course_id` also
+  returns `course`, `course_unit`, `course_resource`, and `all` items).
+- **GET** `…/media-resources/{id}/` — retrieve one media resource by numeric id.
+
+### Search
+
+- **GET** `…/media-resources/search/` — paginated search action. **`q`
+  required** (icontains across `title`, `description`, `course_id`, `unit_id`,
+  `item_id`, `file_url`). Optional result filters `course_id`, `unit_id`,
+  `item_id` (same item_type-spanning behavior as the list endpoint, applied
+  before the `q` match). Returns the standard paginated envelope.
+
+### By-item
+
+- **GET** `…/media-resources/by_item/` — fetch media for one catalog item.
+  **`item_type` and `item_id` both required** (missing → `400`). `item_type`
+  values: `course`, `unit`, `resource`, `course_unit`, `course_resource`,
+  `unit_resource`, `all`. For `course`/`unit`/`resource`, the lookup matches
+  the corresponding id (`course_id`/`unit_id`/`item_id` = `item_id`) **or** any
+  `item_type` that spans that level; for the combined types it matches
+  `item_type` + `item_id` exactly. Returns the standard paginated envelope.
+
+## Writes
+
+### Media resources (CRUD)
+
+- **POST** `…/media-resources/` — create a media resource. **Admin only.**
+  Accepts JSON or **multipart/form-data** (for the `file` upload). At least one
+  of `course_id` / `unit_id` / `item_id` is required; `item_type` is computed
+  server-side and is read-only. Confirm with the user first (file upload /
+  write):
+  ```json
+  {
+    "title": "string (required)",
+    "media_type": "video|image|document|audio|other (required)",
+    "description": "string",
+    "file": "binary file (multipart only)",
+    "file_url": "https://… (external URL)",
+    "course_id": "course-v1:ORG+NUM+RUN",
+    "unit_id": "block-v1:ORG+NUM+RUN+type@vertical+block@…",
+    "item_id": "string"
+  }
+  ```
+  Provide either `file` (upload) or `file_url` (external link). Creating a
+  second resource with the same `file`/`file_url` for the same
+  `item_type` + `item_id` is rejected as a duplicate (`400`). `created_by` is
+  set to the path `{user_id}`; `platform` is set from `{org}`.
+- **PUT** `…/media-resources/{id}/` — full update. **Admin only.** Same body
+  fields as create (multipart supported). Same duplicate-`file`/`file_url`
+  guard. `item_type`/`platform`/`created_by` stay read-only. Confirm with the
+  user first.
+- **PATCH** `…/media-resources/{id}/` — partial update (same rules as PUT).
+  Confirm with the user first.
+- **DELETE** `…/media-resources/{id}/` — delete a media resource by id. Confirm
+  with the user first.
+
+## Example
+
+List the first page of an org's media resources filtered to one course (note
+the URL-encoded `course_id`):
+
+```bash
+curl -G \
+  "https://api.iblai.app/dm/api/media/orgs/$IBLAI_ORG/users/36/media/media-resources/" \
+  -H "Authorization: Api-Token $IBLAI_API_KEY" \
+  --data-urlencode "course_id=course-v1:main+NB101+2025-T1" \
+  --data-urlencode "page_size=10"
+```
+
+Search across an org's media for "lecture":
+
+```bash
+curl -G \
+  "https://api.iblai.app/dm/api/media/orgs/$IBLAI_ORG/users/36/media/media-resources/search/" \
+  -H "Authorization: Api-Token $IBLAI_API_KEY" \
+  --data-urlencode "q=lecture"
+```
+
+## Notes
+
+- **item_type values** (the catalog level a media resource is associated with):
+  `course`, `unit`, `resource`, `course_unit`, `course_resource`,
+  `unit_resource`, `all`. It is **never sent by the client** — the server
+  computes it from which of `course_id` / `unit_id` / `item_id` are present
+  (`course`+`unit`+`item` → `all`; `course`+`unit` → `course_unit`;
+  `course`+`item` → `course_resource`; `unit`+`item` → `unit_resource`; a
+  single id → that single type). It is exposed read-only in responses.
+- **media_type values:** `video`, `image`, `document`, `audio`, `other`.
+- **File upload.** Send `file` as `multipart/form-data` (binary), or instead
+  give an external `file_url`. Uploading the same file/URL for the same
+  item is rejected as a duplicate. Treat uploads as outward-facing — confirm
+  with the user first.
+- **Pagination envelope** (custom; not the catalog `{count,next_page,…}`
+  shape). List/search/by-item return:
+  ```json
+  {
+    "status": { "success": true, "description": "Successfully retrieved media resources" },
+    "results": { "count": 1, "next": null, "previous": null, "data": [ … ] }
+  }
+  ```
+  Page size is `page_size` (default `10`, max `100`); page via `page`. Detail,
+  create, and update responses return the bare serialized object instead.
+- **Resource fields** in `data[]`: `id`, `title`, `description`, `media_type`,
+  `item_type`, `course_id`, `unit_id`, `item_id`, `platform`, `file_url`,
+  `file`, `created_by`, `created_at`, `updated_at`. `created_by`, `created_at`,
+  `updated_at`, `item_type`, and `platform` are read-only.
+- **Permissions** (`MediaResourcePermission`): the path `{user_id}` must have an
+  **active `UserPlatformLink`** to the `{org}` platform. Reads (safe methods)
+  need only that active link; **writes (POST/PUT/PATCH/DELETE) additionally
+  require that link to be admin** (`is_admin`). A missing user, unknown org, or
+  no active link all fail the check. Object-level access also requires the
+  resource's `platform.org` to equal the path `{org}`.
+- **Org / user resolution.** `{org}` is matched against `Platform.org` and
+  `{user_id}` against `User.id`; an unknown org yields an empty result set (or
+  permission failure on writes). Unlike the rest of `/iblai-catalog`, org and
+  user are **path segments**, not query/body params.

--- a/skills/iblai-catalog/SKILL.md
+++ b/skills/iblai-catalog/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: iblai-catalog
+description: Manage an ibl.ai organization's learning catalog via the platform API — courses, programs, pathways, resources, skills, roles, course/program metadata, plus enrollment, eligibility checks, catalog search, and course reviews. Org-wide content and enrollment operations. Use when wiring up the catalog, enrolling users, checking eligibility, or curating skills/roles/pathways.
+---
+
+# iblai-catalog
+
+Manage an organization's **learning catalog** from the API: courses, programs,
+pathways, and resources; the skills and roles taxonomy (including each user's
+desired/reported skills and roles); course and program metadata; plus
+enrollment (course / program / pathway, admin and self), eligibility checks,
+catalog search, and course reviews. Use when populating the catalog, enrolling
+users, checking who can take what, or curating the skills/roles graph.
+
+## Auth & conventions
+
+- **Base URL:** `https://api.iblai.app/dm` — these are Data Manager (DM)
+  endpoints, so the **`/dm` prefix is required**; the `/api/catalog/...` paths
+  below are appended to it (e.g. `https://api.iblai.app/dm/api/catalog/courses/`).
+- **Header:** `Authorization: Api-Token $IBLAI_API_KEY` on every request.
+- **Path vars:** `{org}` = `$IBLAI_ORG` (a.k.a. `org` / `platform_key` /
+  `platform_org` on the wire), `{username}` = `$IBLAI_USERNAME`. Org/user are
+  passed as **query params or body fields**, **not** baked into the path.
+- DELETE / destructive / outward-facing calls say "Confirm with the user first."
+- `course_id` values must be **URL-encoded** in query strings.
+- Not connected yet? Run **`/iblai-login`** first to populate `IBLAI_ORG`,
+  `IBLAI_USERNAME`, and `IBLAI_API_KEY`.
+
+## Reads
+
+### Courses
+
+- **GET** `/api/catalog/courses/` — retrieve courses; filter by `course_id`, `slug` (case-insensitive), `org` (query params). Returns `[{course_id, name, slug, org}]`.
+
+### Programs
+
+- **GET** `/api/catalog/programs/` — retrieve programs; filter by `program_id`, `course_id`, `name`, `slug`, `enabled`, `org` (query params). Returns `[{program_id, org, slug, name, program_type, platform_key, enabled, course_list}]`.
+
+### Pathways
+
+- **GET** `/api/catalog/pathways/` — retrieve pathway(s); filter (query params) by `pathway_id`, `pathway_uuid`, `user_id`/`username`, `platform_key`, `item_id`, `name`, `slug` (case-insensitive), `visible`. Returns a (non-paginated) list of pathways, each with a `path[]` of items.
+
+### Resources
+
+- **GET** `/api/catalog/resources/` — retrieve resources; filter (query params) by `id`, `user_id`/`username`, `platform_key`/`key`, `org`/`platform_org`, `resource_type`, `name`, `query` (matches `name` via icontains), `item_id`. Returns a non-paginated list.
+- **GET** `/api/catalog/resources/search/` — paginated resource search; same filters, `page` (default `1`), `page_size` (default `50`). Results newest-first. Prefer this for large result sets.
+
+### Metadata
+
+#### Course
+
+- **GET** `/api/catalog/metadata/course/` — read a course's metadata by `course_id` (query param; the response keys are dynamic, e.g. `{subject, tags, level, topics, promotion, slug, ...}`). `GET /api/catalog/metadata/course/{field}/` reads one metadata field.
+- **GET** `/api/catalog/metadata/course-public/` — read a course's **public** metadata by `course_id` (no auth/permission required; ignores course visibility). `course-public/{field}/` reads one field. Read-only.
+
+#### Program
+
+- **GET** `/api/catalog/metadata/program/` — read a program's metadata; **`program_id` required**, optional `org` (query params). `program/{field}/` reads one field.
+- **GET** `/api/catalog/metadata/program-public/` — read a program's **public** metadata (`program_id` required, optional `org`; no auth required). `program-public/{field}/` reads one field. Read-only.
+
+#### Choices
+
+- **GET** `/api/catalog/metadata/choices/` — query allowed metadata choices; requires `field_key` **or** `scope` (query params), optional `org`. Returns the choice dict (`404` if none).
+
+### Skills
+
+- **GET** `/api/catalog/skills/` — retrieve skills (paginated); filter by `id`, `name`, `name__iexact`, `slug`, `platform_key`; `sort` (default `id`).
+- **GET** `/api/catalog/skills/desired/` — a user's desired skills by `user_id`/`username` (`400` if the user has none).
+- **GET** `/api/catalog/skills/reported/` — a user's reported skills by `user_id`/`username` (`200` with an empty record `{"user_id":null,"username":null,"skills":[],"data":null}` when there are none).
+
+### Roles
+
+- **GET** `/api/catalog/roles/` — retrieve roles (paginated); filter by `id`, `name`, `name__iexact`, `slug`, `platform_key`; `sort` (default `id`). Each role embeds its `skills[]`.
+- **GET** `/api/catalog/roles/desired/` — a user's desired roles by `user_id`/`username`.
+- **GET** `/api/catalog/roles/reported/` — a user's reported roles by `user_id`/`username`.
+
+### Eligibility
+
+- **GET** `/api/catalog/eligibility/courses/` — list courses a user is eligible for; params `user_id`/`username`, `org`, `query`.
+- **GET** `/api/catalog/eligibility/courses/check/` — check eligibility for one course; **`course_id` required** plus `user_id` **or** `username` (`course_id` URL-encoded), plus `org`, `local_only` (skip the remote edX enroll-status call). Always returns `{is_eligible}`; unless `local_only` is set, the response is merged with the edX enroll-status fields (e.g. `is_enrolled`, etc.).
+
+### Enrollment
+
+#### Courses
+
+- **GET** `/api/catalog/enrollment/courses/search/` — paginated enrollment search; query params (at least one of `user_id`, `username`, `email`, `course_id`, `slug`, `org`, `platform_key` required) plus `course_name` (substring), `sort` (default `-id`), `include_default_platform`, `include_archived_courses` (default false), `page`, `page_size`. Returns `{count, next_page, previous_page, results[]}` of active enrollments.
+
+#### Programs
+
+- **GET** `/api/catalog/enrollment/programs/` — query program enrollments; a user identifier (`user_id`/`username`) is required (the call `400`s on an unresolvable user), and you may also filter by `program_id`/`slug`, `org`/`platform_key`, `program_type` (`standard`|`platform`|`custom`), `include_metadata` (default `true`), `include_default_platform`.
+- **GET** `/api/catalog/enrollment/programs/search/` — paginated program-enrollment search; same params as the GET above plus `sort`, `page`, `page_size`. Active enrollments only.
+
+#### Pathways
+
+- **GET** `/api/catalog/enrollment/pathways/` — query pathway enrollments; a user identifier (`user_id`/`username`) is required, plus optional `pathway_id`/`pathway_uuid`/`slug`, `org`/`platform_key`, `include_metadata` (default `true`), `include_default_platform`.
+- **GET** `/api/catalog/enrollment/pathways/search/` — paginated pathway-enrollment search; user identifier required, plus `pathway_id`/`slug`, `org`/`platform_key`, `sort`, `page`, `page_size`, `include_default_platform`. Active enrollments only.
+
+### Recommendation
+
+- **GET** `/api/catalog/recommendation/courses/` — get the recommended "next" course relative to a current course. **`course_id` required** (query param), plus optional `user_id` and `org`. Returns a single serialized course, or `null` (with `200`) when there is no next course.
+
+### Reviews
+
+#### Course reviews
+
+- **GET** `/api/catalog/reviews/course/` — paginated list of (visible) course reviews; filter (query params) by `course_id`, `user_id`, `platform_key`, `platform_org`/`org`, `sort` (default `-id`), `page`, `page_size`. Returns `{count, next_page, previous_page, results[]}` where each result is `{user_id, username, content, rating, title, visible, created, modified, course_id, metadata}`.
+- **GET** `/api/catalog/reviews/course/info/` — aggregate review stats for a course; **`course_id` required** (query param). Returns `{course_id, avg_rating, count}`.
+
+#### Program reviews
+
+- **GET** `/api/catalog/reviews/program/` — paginated list of (visible) program reviews; filter by `program_id`, `user_id`, `platform_key`, `platform_org`/`org`, `sort`, `page`, `page_size`. Each result includes `program_key`.
+- **GET** `/api/catalog/reviews/program/info/` — aggregate review stats; **`program_key` required** (query param). Returns `{program_key, avg_rating, count}`.
+
+## Writes
+
+### Courses
+
+- **POST** `/api/catalog/courses/` — create/update a course (`200` updated, `201` created):
+  ```json
+  { "course_id": "string (required)", "org": "string (required)", "name": "string (optional)" }
+  ```
+  Newly created courses are assigned to the org's platform (default platform if `org` is unknown). On update the org is only changed if you also send `overwrite_existing_org: true`. (The handler ignores `slug`/`data` on write.)
+- **DELETE** `/api/catalog/courses/` — delete a course by `course_id` (query param). Confirm with the user first.
+
+### Programs
+
+- **POST** `/api/catalog/programs/` — create/update a program (`200` updated, `201` created). Identify the platform by `program_id` + (`org`/`platform_key`) **or** by `program_key`. `program_id`, `name`, and `course_list` are required:
+  ```json
+  {
+    "program_id": "string (required)", "name": "string (required)",
+    "course_list": [{ "course_id": "course-v1:A+B+C" }],
+    "org": "string", "platform_key": "string", "program_key": "string",
+    "slug": "string", "enabled": "boolean (default true)",
+    "program_type": "number (1=standard, 2=platform, 3=custom)",
+    "data": "object"
+  }
+  ```
+- **DELETE** `/api/catalog/programs/` — delete a program by `program_id` + `org` (query params, both required). Returns `{count, type}`. Confirm with the user first.
+
+### Pathways
+
+- **POST** `/api/catalog/pathways/` — create/update a pathway. **`user_id` (required), `name` (required), and `path` (required)**. Use (`user_id`/`username` or `platform_key`) + `pathway_id` to create; do **not** send `pathway_uuid` on create (generated). For an existing pathway, identify by `pathway_uuid`. Each `path[]` item is keyed by `item_type`: `resource` (resource fields below; created on the fly when no `id`), `course` (`course_id`), `program` (`program_key`), or `pathway` (`pathway_id`).
+  ```json
+  {
+    "user_id": "number (required)", "name": "string (required)",
+    "username": "string", "platform_key": "string",
+    "pathway_id": "string", "pathway_uuid": "uuid (update only)",
+    "slug": "string", "visible": "boolean (default true)",
+    "path": [
+      { "item_type": "resource", "id": "number (omit to create)", "resource_type": "string", "url": "string", "name": "string", "description": "string", "data": "object" },
+      { "item_type": "course", "course_id": "course-v1:A+B+C" },
+      { "item_type": "program", "program_key": "program-v1:org+id" }
+    ],
+    "data": "object"
+  }
+  ```
+
+### Resources
+
+- **POST** `/api/catalog/resources/` — create/update a resource (omit `id` to create). Accepts JSON or multipart (for `image`):
+  ```json
+  { "id": "number (update only)", "username": "string", "user_id": "number", "platform_key": "string", "platform_org": "string", "name": "string", "url": "string", "resource_type": "string", "description": "string", "skills": ["string"], "image": "file (multipart)", "data": "object" }
+  ```
+- **DELETE** `/api/catalog/resources/` — delete a resource; requires `id` plus `user_id` or `platform_key` (query params). Returns `{count, type}`. Confirm with the user first.
+
+### Metadata
+
+#### Course
+
+- **POST** `/api/catalog/metadata/course/` — create/update course metadata. **`course_id` and `metadata` required.** With `update: true` (default) the supplied keys are merged; `update: false` overwrites. Special keys inside `metadata`: `slug`, `skills` (list of **existing** skill names). Field-path POSTs (`course/{field}/`) are not supported (`404`).
+  ```json
+  { "course_id": "string", "update": "boolean (default true)", "metadata": { "subject": "string", "tags": ["string"], "level": "string", "topics": ["string"], "promotion": "string|null", "slug": "string", "skills": ["string"] } }
+  ```
+- **POST** `/api/catalog/metadata/course-search/` — return course info (`to_json()`) for courses matching metadata filters in the body, e.g. `{ "data__contains": {...}, "slug": "string", "course_id": "string" }`. Body must be non-empty; invalid filter keys return `400`.
+
+#### Program
+
+- **POST** `/api/catalog/metadata/program/` — create/update program metadata; **`program_id` required**, optional `org`, plus `metadata` and `update` (default true) in the body. Field-path POSTs not supported (`404`).
+
+### Skills
+
+- **POST** `/api/catalog/skills/` — create/update a skill (omit `id` to create; `platform_key: null` for global):
+  ```json
+  { "id": "number (update only)", "name": "string", "slug": "string", "platform_key": "string|null", "data": "object" }
+  ```
+- **POST** `/api/catalog/skills/public/` — create a skill, open to any user (config-gated; names lowercased/trimmed): `{ "name": "string", "slug": "string", "data": "object" }`.
+- **POST** `/api/catalog/skills/desired/` — set a user's desired skills (refer to skills by `id`):
+  ```json
+  { "user_id": "number", "username": "string", "skills": [{ "id": "number" }], "data": "object" }
+  ```
+- **POST** `/api/catalog/skills/reported/` — set a user's reported skills (same shape as desired).
+
+### Roles
+
+- **POST** `/api/catalog/roles/` — create/update a role (omit `id` to create):
+  ```json
+  { "id": "number (update only)", "name": "string", "slug": "string", "platform_key": "string", "data": "object" }
+  ```
+- **POST** `/api/catalog/roles/public/` — create a role, open to any user (config-gated; names lowercased/trimmed): `{ "name": "string", "slug": "string", "data": "object" }`.
+- **POST** `/api/catalog/roles/desired/` — set a user's desired roles: `{ "user_id": "number", "roles": ["string"|{ "id": "number" }], "data": "object" }`.
+- **POST** `/api/catalog/roles/reported/` — set a user's reported roles (same shape as desired).
+
+### Enrollment
+
+#### Programs
+
+- **POST** `/api/catalog/enrollment/programs/` — create/update an enrollment. Requires a user (`user_id`/`username`) and a program (`program_key` **or** `program_id` + `org`/`platform_key`):
+  ```json
+  { "user_id": "number", "username": "string", "program_id": "string", "program_key": "string", "org": "string", "platform_key": "string", "started": "datetime", "expired": "datetime", "active": "boolean (default true)" }
+  ```
+- **DELETE** `/api/catalog/enrollment/programs/` — deactivate an enrollment (query params: user `user_id`/`username` + program `program_id`/`program_key` + `org`/`platform_key`, optional `ignore_expiration` default `false`). Confirm with the user first.
+- **POST** `/api/catalog/enrollment/programs/self/` — self-enrollment (the program must be in a platform the target user belongs to; `403` otherwise). Same body as the admin POST, including `user_id`/`username`:
+  ```json
+  { "user_id": "number", "username": "string", "program_id": "string", "program_key": "string", "org": "string", "platform_key": "string", "started": "datetime", "expired": "datetime", "active": "boolean (default true)" }
+  ```
+- **DELETE** `/api/catalog/enrollment/programs/self/` — self-unenroll (same identifiers as the admin DELETE; membership-checked, optional `ignore_expiration` default `false`). Confirm with the user first.
+
+#### Pathways
+
+- **POST** `/api/catalog/enrollment/pathways/` — create a pathway enrollment; requires a user (`user_id`/`username`) and a pathway (`pathway_uuid`, **or** `pathway_id` + `org`/`platform_key`):
+  ```json
+  { "username": "string", "user_id": "number", "pathway_id": "string", "pathway_uuid": "uuid", "org": "string", "platform_key": "string", "active": "boolean (default true)" }
+  ```
+- **DELETE** `/api/catalog/enrollment/pathways/` — deactivate a pathway enrollment (same identifiers, query params). Confirm with the user first.
+- **POST** `/api/catalog/enrollment/pathways/self/` — self-enrollment (membership-checked; `403` if the user is not in the pathway's platform). Same body as the admin POST, including `user_id`/`username`.
+- **DELETE** `/api/catalog/enrollment/pathways/self/` — self-unenroll (same identifiers, membership-checked). Confirm with the user first.
+
+### Search
+
+- **POST** `/api/catalog/search/programs/` — full-text program search across `program_id`, `name`, `slug`, and `metadata`; returns catalog program objects with `metadata`:
+  ```json
+  { "query": "string", "org": "string (optional)" }
+  ```
+
+### Reviews
+
+#### Course reviews
+
+- **POST** `/api/catalog/reviews/course/update/` — create/update a course review (`201` created, `200` updated). **`course_id` and `username` required** (or `user_id`):
+  ```json
+  { "course_id": "string", "username": "string", "user_id": "number", "rating": "number", "title": "string", "content": "string", "visible": "boolean (default true)", "metadata": "object" }
+  ```
+- **DELETE** `/api/catalog/reviews/course/update/` — delete a user's course review; **`course_id` + `username`/`user_id` required** (query params). Confirm with the user first.
+
+#### Program reviews
+
+- **POST** `/api/catalog/reviews/program/update/` — create/update a program review. **`program_key` and `username` required** (or `user_id`):
+  ```json
+  { "program_key": "program-v1:org+id", "username": "string", "user_id": "number", "rating": "number", "title": "string", "content": "string", "visible": "boolean (default true)", "metadata": "object" }
+  ```
+- **DELETE** `/api/catalog/reviews/program/update/` — delete a user's program review; **`program_key` + `username`/`user_id` required** (query params). Confirm with the user first.
+
+## Example
+
+Check whether a user is eligible for a specific course (note the URL-encoded `course_id`):
+
+```bash
+curl -G \
+  "https://api.iblai.app/dm/api/catalog/eligibility/courses/check/" \
+  -H "Authorization: Api-Token $IBLAI_API_KEY" \
+  --data-urlencode "user_id=36" \
+  --data-urlencode "org=$IBLAI_ORG" \
+  --data-urlencode "course_id=course-v1:IBLTEST+IBL000+RUN"
+```
+
+## Notes
+
+- **All endpoints are DM endpoints** served under `https://api.iblai.app/dm` (`/dm` + `/api/catalog/...`). Omitting the `/dm` prefix will not resolve.
+- **Course id format** is the opaque-keys form `course-v1:ORG+NUMBER+RUN` (e.g. `course-v1:IBLTEST+IBL000+RUN`). Always URL-encode it in query strings (`%3A`, `%2B`).
+- **Program ids** are slug-like strings (e.g. `test-program-000`); `program_type` is a numeric code on write. **Resource / skill / role ids** are integers; resources also carry a UUID `item_id`; pathways carry a UUID `pathway_uuid` (generated on create — never send it on a create call).
+- **Org on the wire** appears as `org`, `platform_key`, or (resource search legacy) `platform_org`/`key` — all mean the org key. Pass it as a query param (GET) or body field (POST), not in the path.
+- **Skills/roles by id, not name.** When setting a user's desired/reported skills or roles, reference them by `{"id": …}` (recommended) rather than name. Course-metadata `skills` must reference **existing** skill names.
+- **Self vs admin enrollment.** Both the non-self and the `…/self/` enrollment endpoints take an explicit `user_id`/`username` in the request. The difference is permission scope: `…/self/` additionally checks that the target user is a member of the program/pathway's platform (returns `403` if not), so it is the endpoint to use for non-admin (user-token) self-service; the non-self endpoints are for admin tokens enrolling other users.
+- **Pagination envelope** is `{count, next_page, previous_page, results[]}` for the search/paginated endpoints (course/program/pathway enrollment search, resource search, skills, roles, course/program review query); plain `GET`s like `resources/` and `pathways/` are **not** paginated.
+- `public/` skill and role creation endpoints are config-gated (`ALLOW_PUBLIC_SKILL_CREATE` / `ALLOW_PUBLIC_ROLE_CREATE`) and return `404` when disabled; created names are lowercased and trimmed.
+- **Auto-increment utility.** `GET`/`POST /api/catalog/increment/` reads/advances per-platform auto-increment numbers (`org`/`key`, and `number_type` on `POST`). It is an internal numbering helper, not a catalog-management operation — included for completeness only.
+- The source repo also ships Django management commands (`convert_slugs_lower`, `link_item_objects`, `verify_course_existence`); those are server-side operations, not REST endpoints, and are out of scope for this skill.

--- a/skills/iblai-course-create/SKILL.md
+++ b/skills/iblai-course-create/SKILL.md
@@ -21,25 +21,35 @@ content. Host root for every endpoint below is
 - Not connected yet? Run **`/iblai-login`** first to populate `IBLAI_ORG`,
   `IBLAI_USERNAME`, and `IBLAI_API_KEY`.
 
-## Tasks
+## Reads
 
-- **POST** `…/course-creation/tasks/` — create a task.
+### Tasks
+
 - **GET** `…/course-creation/tasks/` — list tasks.
 - **GET** `…/course-creation/tasks/{task_id}/` — task detail / status (status flows `Pending` → `Scheduled`).
-- **DELETE** `…/course-creation/tasks/{task_id}/` — delete a task. Destructive — confirm with the user first.
-- **POST** `…/course-creation/tasks/{task_id}/create-course/` — create the course on the LMS.
-- **POST** `…/course-creation/tasks/{task_id}/create-course-outline/` — generate the outline with AI.
 - **GET** `…/course-creation/tasks/{task_id}/start/` — start the full creation pipeline.
 - **GET** `…/course-creation/tasks/{task_id}/cancel/` — cancel the pipeline.
 
-## Courses
+### Courses
 
 - **GET** `…/course-creation/course/` — list courses (filter by task with `?task={task_id}`).
 - **GET** `…/course-creation/course/{course_id}/` — course detail.
-- **DELETE** `…/course-creation/course/{course_id}/` — delete the course record. Destructive — confirm with the user first.
 - **GET** `…/course-creation/course/{course_id}/outline/` — outline (no component content).
 - **GET** `…/course-creation/course/{course_id}/full-structure/` — full structure (add `?include_content=true` for HTML).
 - **GET** `…/course-creation/course/{course_id}/draft-content-for-all-units/` — draft content for all units.
+
+## Writes
+
+### Tasks
+
+- **POST** `…/course-creation/tasks/` — create a task.
+- **DELETE** `…/course-creation/tasks/{task_id}/` — delete a task. Destructive — confirm with the user first.
+- **POST** `…/course-creation/tasks/{task_id}/create-course/` — create the course on the LMS.
+- **POST** `…/course-creation/tasks/{task_id}/create-course-outline/` — generate the outline with AI.
+
+### Courses
+
+- **DELETE** `…/course-creation/course/{course_id}/` — delete the course record. Destructive — confirm with the user first.
 - **POST** `…/course-creation/course/{course_id}/draft-content-for-unit/` — draft content for one unit.
 
 ## Example

--- a/skills/iblai-credentials/SKILL.md
+++ b/skills/iblai-credentials/SKILL.md
@@ -1,0 +1,381 @@
+---
+name: iblai-credentials
+description: Manage an ibl.ai organization's digital credentials via the platform API — credential CRUD, user/group assignments, assertions, course-scoped credential import/export, external provider config + mapping (Accredible), and issuance analytics. Use when issuing, assigning, importing, or reporting on digital credentials and certificates.
+---
+
+# iblai-credentials
+
+Manage an organization's **digital credentials** from the API: create and edit
+credentials, assign them to users and groups, read the resulting assertions
+(issued credentials), import/export course-scoped credentials between platforms,
+wire up external issuing providers (e.g. Accredible) via provider config and
+per-credential external mappings, and pull issuance analytics over time. Use when
+issuing, assigning, importing, or reporting on digital credentials and
+certificates.
+
+## Auth & conventions
+
+- **Base URL:** `https://api.iblai.app/dm` — these are Data Manager (DM)
+  endpoints, so the **`/dm` prefix is required**; the `/api/credentials/…` paths
+  below are appended to it (e.g. `https://api.iblai.app/dm/api/credentials/…`).
+- **Header:** `Authorization: Api-Token $IBLAI_API_KEY` on every request.
+- **Path vars:** `{org}` = `$IBLAI_ORG` (the credentials API path segment is
+  `platform_key`; it resolves against `Platform.key`, with `Platform.org` as a
+  fallback; on the wire it is also the `platform_org` query param). The user
+  segment accepts **either** a numeric `{user_id}` **or** a `{username}` — both
+  route shapes exist (`…/users/<int:user_id>/…` and `…/users/<str:username>/…`),
+  so `$IBLAI_USERNAME` works directly in the path. For provider-config/mapping
+  paths that user segment is the admin making the request (use `$IBLAI_USERNAME`).
+  `{course_id}` = an Open edX course id such as `course-v1:org+course+run`.
+- **Most paths are user-scoped** under
+  `/api/credentials/orgs/{org}/users/{user}/…` (where `{user}` is a numeric id or
+  username). Below, that prefix is written as **`…/`** for brevity. The course
+  import/export (`exim`) endpoints, the public assertion lookup, and the public
+  provider list are platform-agnostic and live directly under
+  `/api/credentials/…` with **no** org/user segment.
+- **Ids:** id-taking detail endpoints (credentials, assertions, assignments)
+  look up **by `entity_id`** (the UUID string) only — numeric database ids are
+  not accepted. `{id}` below means the `entity_id`.
+- **Responses** are wrapped: `{"status": {"success": bool, "description": str},
+  "result": {…}}`. Paged list `result` objects carry `count`, `next`,
+  `previous`, and either `results` or `data`.
+- DELETE / destructive / outward-facing (assign, issue, import/export) calls —
+  **confirm with the user first.**
+- Not connected yet? Run **`/iblai-login`** first to populate `IBLAI_ORG`,
+  `IBLAI_USERNAME`, and `IBLAI_API_KEY`.
+
+## Pagination, ordering & search (list endpoints)
+
+- `page` (default `1`), `page_size` (default `10`, max `100`; provider/mapping
+  lists default `50`, max `1000`).
+- `search` — case-insensitive match across the relevant fields (username, email,
+  full name, credential name/description, group name, platform name, course/program
+  name, assigned-by username, depending on the endpoint).
+- Results are ordered newest-first (by creation / assignment date). For
+  department admins, results are automatically filtered to their department scope.
+
+## Reads
+
+### Credentials — `…/`
+
+- **GET** `…/` — list credentials for the org (only `public=True` credentials are
+  returned). Query params: `search` (name / name_override / description),
+  `course` (course id), `program` (program id), `page`, `page_size`.
+- **GET** `…/{id}` — read one credential (`{id}` = `entity_id`).
+- **GET** `…/course-credentials/` — list credentials grouped by course. Query
+  params: `search` (course name / course id), `page`, `page_size`. The paged
+  `result` carries `results` (not `data`).
+- **GET** `…/images/` — search uploaded credential images. **Requires** a
+  `query` param (case-insensitive name match); returns an array of
+  `{id, name, image}`.
+
+### Issuers & signatories — `…/issuers/`
+
+An issuer is required to create a credential (its `entityId` is the `issuer`
+field above). Issuers are keyed to the platform.
+
+- **GET** `…/issuers/` — list issuers for the org. Query params: `q` (search by
+  name), plus `page`/`page_size`. Each issuer has `name`, `org`, `entityId`,
+  `signatories`, `url`, `iconImage`, `allowed_template_tags`.
+- **GET** `…/issuers/{id}` — read one issuer (`{id}` = issuer `entity_id`, or its
+  `org` identifier).
+
+### Assignments (users & groups) — `…/assignments/`
+
+Assignments link a credential to users or groups; issuing an assignment produces
+assertions. Group assignments are processed asynchronously (Celery). Department
+admins only see/act on assignments within their department scope.
+
+- **GET** `…/assignments/users/` — list/search user assignments (also serves as
+  the role-filtered **assertions for users** view — see Notes). Only assignments
+  with `status == "COMPLETED"` that have a matching non-revoked assertion are
+  returned. Supports `search` (credential name / username / email), `page`,
+  `page_size`, and optional `platform_org`.
+- **GET** `…/assignments/groups/` — list group assignments (department-filtered).
+  Optional `group_id` filter; `page`, `page_size`.
+
+### Assertions — `…/assertions/`
+
+An assertion is an issued credential (a credential granted to a user).
+
+- **GET** `…/assertions/` — list all assertions for this user/org. Query params:
+  `course` (filter by course id), `include_revoked` (default false),
+  `include_expired` (default false), `exclude_main_tenant_assertions` (default
+  false), `page`, `page_size`. Response fields are camelCase: `entityId`,
+  `issuedOn`, `credentialDetails`, `recipient`, `course`, `program`, `revoked`,
+  `revocationReason`, `acceptance`, `expires`, `metadata`, `narrative`.
+- **GET** `…/assertions/{id}` — read one assertion (`{id}` = assertion
+  `entity_id`).
+- **GET** `/api/credentials/public/assertions/{id}/` — **public**, unauthenticated
+  lookup of a single assertion by `entity_id` (no org/user segment, no auth
+  header needed). Returns 404 if not found or revoked (revoked responses include
+  the revocation reason).
+
+### Course import/export (exim) — `/api/credentials/exim/…`
+
+Platform-agnostic; no org/user segment. **DM admin only.** Export converts item
+ids to course ids in the response; import converts course ids to item ids and
+replaces the issuer with the platform's default issuer.
+
+- **GET** `/api/credentials/exim/credentials/course/{course_id}/export/` — export
+  all credential definitions for a course (returns `course_id` + a `credentials`
+  array with `entityId`, `name`, templates, `expires`, `issuerDetails`,
+  `signatories`, `courses`, `programs`, `pathways`, etc.).
+
+### Provider config / external mapping — `…/provider-config/`, `…/external-mapping/`
+
+**Platform admin only** (`Requires platform admin access`). Path uses
+`…/users/{username}/…` where `{username}` is the admin making the request. These
+configure external issuers (e.g. Accredible) and map internal credentials to
+external templates.
+
+#### Available providers (public list) — `/api/credentials/providers/`
+
+- **GET** `/api/credentials/providers/` — list enabled credential providers (no
+  org/user segment; only requires authentication, not admin). Optional `page`,
+  `page_size` (default 50, max 1000). Each entry: `name`, `display_name`,
+  `description`, `enabled`, `metadata`.
+
+#### Provider configuration — `…/provider-config/`
+
+- **GET** `…/provider-config/` — list provider configs. Optional `provider_name`,
+  `page`, `page_size`. Each entry has `provider_name`, `provider_name_display`,
+  `config` (provider settings), `enabled`.
+
+#### External credential mapping — `…/external-mapping/`
+
+- **GET** `…/external-mapping/` — list mappings. Optional `credential_id`
+  (filter by credential entity_id), `provider_name`, `page`, `page_size`.
+
+### Analytics — `…/`
+
+All take optional `start_date` / `end_date` (`YYYY-MM-DD`) query params and return
+`{ "data": { "<date>": count, … } }` (back-filled with zero-value days when a
+range is given).
+
+- **GET** `…/assertions-over-time/` — assertion (issuance) counts over time.
+  **Platform admin only.** Also returns a `meta` block with totals and percent
+  changes.
+- **GET** `…/course-assertions-over-time/` — per-course assertion counts over
+  time. **Platform admin only.**
+- **GET** `…/credentials-over-time/` — credential-creation counts over time.
+
+## Writes
+
+### Credentials — `…/`
+
+- **POST** `…/` — create a credential. Confirm with the user first. `name` and
+  `issuer` (the **issuer entity_id**) are **required**; everything else is
+  optional:
+  ```json
+  {
+    "name": "string",
+    "issuer": "issuer-entity-id",
+    "description": "string",
+    "criteriaUrl": "string",
+    "criteriaNarrative": "string",
+    "credentialType": "string",
+    "signal": "COURSE_PASSED",
+    "html_template": "string",
+    "css_template": "string",
+    "tags": [],
+    "metadata": {},
+    "expires": { "amount": 365, "duration": "days" },
+    "iconImage": "url", "backgroundImage": "url", "thumbnailImage": "url",
+    "courses": ["course-v1:org+course+run"],
+    "programs": ["program-id"],
+    "pathways": ["pathway-id"]
+  }
+  ```
+  `signal` defaults to `COURSE_PASSED`. Body field names are camelCase as shown
+  (these map to the credential output fields). The response `result` uses
+  `entityId`, `criteriaUrl`, `criteriaNarrative`, `credentialType`, `signal`,
+  `issuerDetails`, `signatories`, `courses`, `programs`, `pathways`, `expires`,
+  etc.
+- **PUT** `…/{id}` — update one credential (partial; only present fields change).
+  Updatable fields: `name`, `description`, `html_template`, `css_template`,
+  `credentialType`, `criteriaUrl`, `criteriaNarrative`, `signal`, `iconImage`,
+  `backgroundImage`, `thumbnailImage`, `metadata` (merged into existing).
+- **DELETE** `…/{id}` — delete one credential. Confirm with the user first.
+  Returns **409 Conflict** if the credential still has active (non-revoked,
+  unexpired) assertions — revoke/delete those first.
+- **POST** `…/images/` — upload an image as multipart form
+  data (`image` file, optional `name`); returns the created `{id, name, image}`.
+
+### Issuers & signatories — `…/issuers/`
+
+- **POST** `…/issuers/` — create an issuer. Confirm with the user first. Body:
+  `name` (and optionally `iconImage`, `email`, `url`, `allowed_template_tags`).
+- **PUT** `…/issuers/{id}` — update an issuer. Confirm with the user first.
+- **DELETE** `…/issuers/{id}` — delete an issuer. Confirm with the user first.
+- **POST** `…/issuers/authority/` — create a signatory (issuer authority).
+  Confirm with the user first. Body: `name`, `title`, `signature` (image url)
+  required; optionally `org`, `entityId` (issuer entity id), or `credential`
+  (credential entity id) to associate it. If none of `org`/`entityId`/`credential`
+  is given, it falls back to the platform from the URL.
+
+### Assignments (users & groups) — `…/assignments/`
+
+- **POST** `…/assignments/users/` — assign a credential to users. Confirm with the user first:
+  ```json
+  { "credential_id": "credential-entity-id", "user_ids": [123, 456] }
+  ```
+  `user_ids` are numeric user ids. Returns `result` with `successful_assignments`,
+  `failed_assignments`, and `message`.
+- **POST** `…/assignments/groups/` — assign a credential to groups (async). Confirm with the user first:
+  ```json
+  { "credential_id": "credential-entity-id", "group_ids": ["group-id-1", "group-id-2"] }
+  ```
+  `credential_id` and `group_ids` are both required (`group_ids` are strings).
+  Returns `result` with `successful_assignments` / `failed_assignments`.
+- **DELETE** `…/assignments/{id}` — delete one assignment (`{id}` = the
+  assignment `entity_id`; resolves to either a group or individual assignment).
+  Confirm with the user first. (This endpoint is DELETE-only — there is no GET on
+  a single assignment.) For a group assignment this cascades to all related user
+  assignments and assertions; for an individual assignment it deletes the
+  assignment and its assertion. The response is a simple
+  `{ "status": { "success": true, "description": "…" } }`.
+
+### Assertions — `…/assertions/`
+
+- **PUT** `…/assertions/{id}` — revoke an assertion. This is outward-facing —
+  confirm with the user first. Body: `{ "revoked": true, "revocationReason":
+  "string" }`.
+- **POST** `…/{id}/assertions/` — issue (create) an assertion for credential
+  `{id}` (= credential `entity_id`). This issues a credential — confirm with the
+  user first. Body requires a `recipient` object and an item the credential is
+  attached to:
+  ```json
+  {
+    "recipient": { "identity": "username" },
+    "course": "course-v1:org+course+run",
+    "metadata": {}
+  }
+  ```
+  Instead of `course` you may pass `catalog_item` (item id), `program` /
+  `program_id`, or `pathway` / `pathway_id` to identify the item.
+- **POST** `…/{id}/assertions/bulk/` — issue the credential to many users at once.
+  Confirm with the user first. Body: `users` is a list of usernames, plus the
+  same item field (`course` / `catalog_item` / `program` / `pathway`) and
+  optional `metadata`. Returns `{ "skipped": [...], "issued": [...] }`.
+
+### Course import/export (exim) — `/api/credentials/exim/…`
+
+- **POST** `/api/credentials/exim/credentials/course/{course_id}/import/` — import
+  credential definitions into a course. Confirm with the user first:
+  ```json
+  {
+    "course_id": "course-v1:org+course+run",
+    "credentials": [
+      {
+        "entityId": "credential-entity-id",
+        "name": "Credential Name",
+        "description": "string",
+        "criteriaUrl": "string",
+        "criteriaNarrative": "string",
+        "credentialType": "COURSE_CERTIFICATE",
+        "expires": { "amount": 365, "duration": "days" },
+        "signatories": [
+          { "entityId": "authority-entity-id", "name": "string", "title": "string", "signature": "url" }
+        ],
+        "html_template": "string",
+        "css_template": "string",
+        "signal": "COURSE_PASSED",
+        "courses": [ { "name": "string", "course_id": "course-v1:org+course+run" } ]
+      }
+    ]
+  }
+  ```
+  Existing credentials (matched by name + course + default issuer) are updated;
+  missing ones are created. Response `result` lists `course_id`,
+  `imported_credentials` (each with `entityId`, `name`, and `status` =
+  `created`|`updated`) and `errors`. Status is 201 if all succeed, **207
+  Multi-Status** if some succeed with errors, 400 if none succeed.
+
+### Provider config / external mapping — `…/provider-config/`, `…/external-mapping/`
+
+#### Provider configuration — `…/provider-config/`
+
+- **POST** `…/provider-config/` — create or update a provider config (201 on
+  create, 200 on update). Confirm with the user first:
+  ```json
+  {
+    "provider_name": "accredible",
+    "config": {
+      "accredible_api_key": "your-api-key",
+      "accredible_base_url": "https://dashboard.accredible.com/",
+      "accredible_api_base_url": "https://api.accredible.com/v1/",
+      "accredible_group_id": "123456",
+      "accredible_template_id": "789012",
+      "use_sandbox": false
+    },
+    "enabled": true
+  }
+  ```
+  `provider_name` is required; `config` and `enabled` are each optional. Config
+  keys are normalized to lowercase; values are preserved verbatim. For
+  `provider_name: "accredible"`, `config` must include `accredible_api_key`
+  (validation rejects it otherwise). Returns 201 + description `Created` on
+  create, 200 + `Updated` on update.
+- **DELETE** `…/provider-config/` — deactivate a provider config (sets
+  `enabled=false`; external issuance is then skipped; the record is not removed).
+  Confirm with the user first. Body: `{ "provider_name": "accredible" }`. Returns
+  description `Deactivated` with the updated config object.
+
+#### External credential mapping — `…/external-mapping/`
+
+- **POST** `…/external-mapping/` — create or update a mapping (201 on create, 200
+  on update; unique per credential + platform + provider). Confirm with the user first:
+  ```json
+  {
+    "credential_id": "credential-entity-id",
+    "provider_name": "accredible",
+    "external_template_id": "123456789",
+    "group_id": "679866",
+    "metadata": {}
+  }
+  ```
+  `credential_id` and `provider_name` are required; `external_template_id`,
+  `group_id`, and `metadata` are optional.
+- **DELETE** `…/external-mapping/` — delete a mapping. Confirm with the user first.
+  Body: `{ "credential_id": "credential-entity-id", "provider_name": "accredible" }`.
+
+## Example
+
+List a user's issued credentials (assertions), searching for "python":
+
+```bash
+curl -G \
+  "https://api.iblai.app/dm/api/credentials/orgs/$IBLAI_ORG/users/$IBLAI_USERNAME/assignments/users/" \
+  -H "Authorization: Api-Token $IBLAI_API_KEY" \
+  --data-urlencode "search=python" \
+  --data-urlencode "page_size=20"
+```
+
+## Notes
+
+- **Role-based assertion filtering** (`…/assignments/users/`): the `{user}` in the
+  path is the user whose role determines visibility — platform admins see
+  assignments for all users in the org; department admins see only users in their
+  department groups; everyone else sees only their own. If the resolved set is
+  empty the call returns 403 ("You don't have permission to view these
+  assignments").
+- **Ids:** detail lookups for credentials, assertions, and assignments are **by
+  `entity_id`** (UUID) only — numeric database ids are not accepted. Course ids
+  are Open edX ids (`course-v1:org+course+run`).
+- **`{org}`** is the `platform_key` URL segment; it resolves against
+  `Platform.key` first, then `Platform.org` as a fallback, and may also be passed
+  as the `platform_org` query param.
+- **Accredible provider specifics:** `config` keys are lowercased on save (values
+  preserved); when issuing, the system uses the mapping's `group_id` first and
+  falls back to the provider config's `accredible_group_id`. `use_sandbox` toggles
+  the Accredible sandbox. Disabling a provider config (`enabled=false`) skips
+  external issuance for that org.
+- **Pagination defaults differ:** assignment/assertion lists default to
+  `page_size=10` (max 100); provider-config and external-mapping lists default to
+  `50` (max 1000).
+- **Group assignments are asynchronous** (Celery); the immediate response confirms
+  acceptance, not completion.
+- Errors use the standard codes: 400 (bad input), 401 (unauthenticated),
+  403 (insufficient permissions, e.g. "Requires platform admin access"),
+  404 (not found), 500 (server error).

--- a/skills/iblai-crm/SKILL.md
+++ b/skills/iblai-crm/SKILL.md
@@ -12,7 +12,9 @@ records for one organization. Use for lead capture, pipelines, and deal flow.
 
 ## Auth & conventions
 
-- **Base URL:** `https://platform.iblai.app/api/crm/`
+- **Base URL:** `https://api.iblai.app/dm` — CRM is a Data Manager (DM)
+  endpoint, so the **`/dm` prefix is required**; the `/api/crm/...` paths below
+  are appended to it (e.g. `https://api.iblai.app/dm/api/crm/persons/`).
 - **Header:** `Authorization: Api-Token $IBLAI_API_KEY` on every request. (The CRM
   developer docs phrase this as `Authorization: Token <key>` — it is the same
   Platform API Token.)
@@ -40,51 +42,90 @@ Each resource supports standard REST: **GET** (list), **POST** (create),
 **GET** `{id}` (read), **PATCH** `{id}` (update), **DELETE** `{id}` (delete).
 DELETE is destructive — confirm with the user first.
 
-### Person — `/api/crm/persons/` (UUID)
+### Useful filters
+
+- `owner={user_id}` — "my pipeline" / "my accounts".
+- `owner__isnull=true` — unowned records.
+- `?is_default=true` on pipelines — the seeded pipeline; its response embeds its
+  stages inline.
+
+## Reads
+
+### Person
 
 - **GET** `/api/crm/persons/` — list people.
-- **POST** `/api/crm/persons/` — create a person.
 - **GET** `/api/crm/persons/{id}/` — read a person.
+
+### Organization
+
+- **GET** `/api/crm/organizations/` — list organizations.
+- **GET** `/api/crm/organizations/{id}/` — read an organization.
+
+### Pipeline
+
+- **GET** `/api/crm/pipelines/` — list pipelines.
+- **GET** `/api/crm/pipelines/{id}/` — read a pipeline.
+
+### Stage
+
+- **GET** `/api/crm/pipelines/{pipeline_id}/stages/` — list a pipeline's stages.
+- **GET** `/api/crm/pipelines/{pipeline_id}/stages/{id}/` — read a stage.
+
+### Lead Source
+
+- **GET** `/api/crm/lead-sources/` — list lead sources.
+- **GET** `/api/crm/lead-sources/{id}/` — read a lead source.
+
+### Deal
+
+- **GET** `/api/crm/deals/` — list deals.
+- **GET** `/api/crm/deals/{id}/` — read a deal.
+
+### Activity
+
+- **GET** `/api/crm/activities/` — list activities.
+- **GET** `/api/crm/activities/{id}/` — read an activity.
+
+### Tag
+
+- **GET** `/api/crm/tags/` — list tags.
+- **GET** `/api/crm/tags/{id}/` — read a tag.
+
+## Writes
+
+### Person
+
+- **POST** `/api/crm/persons/` — create a person.
 - **PATCH** `/api/crm/persons/{id}/` — update a person.
 - **DELETE** `/api/crm/persons/{id}/` — delete a person. Confirm with the user first.
 
-### Organization — `/api/crm/organizations/` (UUID)
+### Organization
 
-- **GET** `/api/crm/organizations/` — list organizations.
 - **POST** `/api/crm/organizations/` — create an organization.
-- **GET** `/api/crm/organizations/{id}/` — read an organization.
 - **PATCH** `/api/crm/organizations/{id}/` — update an organization.
 - **DELETE** `/api/crm/organizations/{id}/` — delete an organization. Confirm with the user first.
 
-### Pipeline — `/api/crm/pipelines/` (int)
+### Pipeline
 
-- **GET** `/api/crm/pipelines/` — list pipelines.
 - **POST** `/api/crm/pipelines/` — create a pipeline.
-- **GET** `/api/crm/pipelines/{id}/` — read a pipeline.
 - **PATCH** `/api/crm/pipelines/{id}/` — update a pipeline.
 - **DELETE** `/api/crm/pipelines/{id}/` — delete a pipeline. Confirm with the user first.
 
-### Stage — `/api/crm/pipelines/{pipeline_id}/stages/` (int, nested under a pipeline)
+### Stage
 
-- **GET** `/api/crm/pipelines/{pipeline_id}/stages/` — list a pipeline's stages.
 - **POST** `/api/crm/pipelines/{pipeline_id}/stages/` — create a stage.
-- **GET** `/api/crm/pipelines/{pipeline_id}/stages/{id}/` — read a stage.
 - **PATCH** `/api/crm/pipelines/{pipeline_id}/stages/{id}/` — update a stage.
 - **DELETE** `/api/crm/pipelines/{pipeline_id}/stages/{id}/` — delete a stage. Confirm with the user first.
 
-### Lead Source — `/api/crm/lead-sources/` (int)
+### Lead Source
 
-- **GET** `/api/crm/lead-sources/` — list lead sources.
 - **POST** `/api/crm/lead-sources/` — create a lead source.
-- **GET** `/api/crm/lead-sources/{id}/` — read a lead source.
 - **PATCH** `/api/crm/lead-sources/{id}/` — update a lead source.
 - **DELETE** `/api/crm/lead-sources/{id}/` — delete a lead source. Confirm with the user first.
 
-### Deal — `/api/crm/deals/` (int)
+### Deal
 
-- **GET** `/api/crm/deals/` — list deals.
 - **POST** `/api/crm/deals/` — create a deal.
-- **GET** `/api/crm/deals/{id}/` — read a deal.
 - **PATCH** `/api/crm/deals/{id}/` — update a deal.
 - **DELETE** `/api/crm/deals/{id}/` — delete a deal. Confirm with the user first.
 
@@ -96,28 +137,17 @@ DELETE is destructive — confirm with the user first.
 - **POST** `/api/crm/deals/{id}/won/` — close the deal as won.
 - **POST** `/api/crm/deals/{id}/lost/` — close the deal as lost.
 
-### Activity — `/api/crm/activities/` (int)
+### Activity
 
-- **GET** `/api/crm/activities/` — list activities.
 - **POST** `/api/crm/activities/` — create an activity.
-- **GET** `/api/crm/activities/{id}/` — read an activity.
 - **PATCH** `/api/crm/activities/{id}/` — update an activity.
 - **DELETE** `/api/crm/activities/{id}/` — delete an activity. Confirm with the user first.
 
-### Tag — `/api/crm/tags/` (int)
+### Tag
 
-- **GET** `/api/crm/tags/` — list tags.
 - **POST** `/api/crm/tags/` — create a tag.
-- **GET** `/api/crm/tags/{id}/` — read a tag.
 - **PATCH** `/api/crm/tags/{id}/` — update a tag.
 - **DELETE** `/api/crm/tags/{id}/` — delete a tag. Confirm with the user first.
-
-### Useful filters
-
-- `owner={user_id}` — "my pipeline" / "my accounts".
-- `owner__isnull=true` — unowned records.
-- `?is_default=true` on pipelines — the seeded pipeline; its response embeds its
-  stages inline.
 
 ## Example
 
@@ -125,7 +155,7 @@ Create a person:
 
 ```bash
 curl -X POST \
-  "https://platform.iblai.app/api/crm/persons/" \
+  "https://api.iblai.app/dm/api/crm/persons/" \
   -H "Authorization: Api-Token $IBLAI_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -138,8 +168,9 @@ curl -X POST \
 
 ## Notes
 
-- The CRM lives on a **different host** than the other `iblai-*` skills:
-  `https://platform.iblai.app/api/crm/`, not `https://api.iblai.app`.
+- CRM is served via the DM gateway at `https://api.iblai.app/dm/api/crm/`
+  (equivalent to the legacy `https://platform.iblai.app/api/crm/` host; skills
+  standardize on the `api.iblai.app/dm` form).
 - Lifecycle stages are `lead | qualified | opportunity | customer | churned`.
 - A CRM Person auto-links to a Platform user when a signup matches by email.
 - Stages are nested under a pipeline; deal transitions go through the deal

--- a/skills/iblai-features/SKILL.md
+++ b/skills/iblai-features/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: iblai-features
+description: Manage an ibl.ai organization's per-user feature configuration and app/onboarding state via the Data Manager (DM) API — read and write a user's feature config (single feature or bulk inline object), bulk-update a feature's values across an entire platform, list the apps a user can access, mark onboarding complete, activate an app free trial, and (when enabled) run an admin platform-provisioning config. Use when toggling feature flags/values for a user or a whole org, reading which apps a user has, updating onboarding status, activating a free trial, or provisioning a platform.
+---
+
+# iblai-features
+
+Manage **per-user feature configuration** and **app / onboarding state** from
+the Data Manager (DM) API: read and write a user's feature config (one feature,
+or a bulk inline `config` object), bulk-apply a feature's `values` across every
+user on a platform, list the apps a user has access to, mark onboarding
+complete, activate an app free trial, and — only when the platform enables it —
+run an admin **platform-provisioning** config. Use when flipping feature
+flags/values for a user or an org, inspecting a user's apps, recording
+onboarding, granting a trial, or provisioning a platform.
+
+## Auth & conventions
+
+- **Base URL:** `https://api.iblai.app/dm` — these are Data Manager (DM)
+  endpoints, so the **`/dm` prefix is required**; the `/api/features/...` (and
+  `/api/provision/...`) paths below are appended to it (e.g.
+  `https://api.iblai.app/dm/api/features/config/`). `/dm` is the gateway prefix
+  and does not appear in the app's `urls.py`.
+- **Header:** `Authorization: Api-Token $IBLAI_API_KEY` on every request.
+- **Path / scope vars:** `{org}` = `$IBLAI_ORG` (a.k.a. `platform_key` on the
+  wire). The org/platform is always passed as a **query param or body field**
+  (`platform_key`), never baked into the path. The user is resolved flexibly
+  from **`user_id` _or_ `username` _or_ `email`** (in that precedence) — passed
+  as query params on GET, body fields on POST.
+- Most feature/app endpoints are open (`AllowAny` — see Notes); the
+  provisioning endpoint is **platform-admin only**. Destructive /
+  outward-facing actions (trial activation) say "Confirm with the user first."
+- Not connected yet? Run **`/iblai-login`** first to populate `IBLAI_ORG`,
+  `IBLAI_USERNAME`, and `IBLAI_API_KEY`.
+
+## Reads
+
+### Feature config
+
+A user's feature config is a set of per-platform `{feature: values}` records.
+Reads return the whole map; writes accept **either** a bulk inline `config`
+object **or** a single `feature` + `values` pair (these two body shapes are
+mutually exclusive — `config` wins if both are present, otherwise `feature` is
+used; sending neither returns `400`).
+
+- **GET** `/api/features/config/` — read a user's feature config. Resolve the
+  user with `user_id`/`username`/`email` (required — `404` if unresolved); scope
+  with `platform_key` (query params). Returns the `{feature: values, ...}` map
+  (empty `{}` if none).
+
+### Apps & onboarding
+
+- **GET** `/api/features/apps/` — list the apps the **authenticated** user has
+  access to (derived from the request token's user — not a `user_id` param).
+  Paginated (`page`, `page_size`; default page size 100). Filterable query
+  params: `app` (matches app name **or** url, icontains), `platform` (platform
+  key, icontains), `has_active_subscription` (bool), `free_trial_started`
+  (bool), `free_trial_expired` (bool), `onboarding_completed` (bool),
+  `created_at` / `updated_at` (datetime range, `*_after` / `*_before`). Each
+  result includes the app, the resolved `platform`, `provider`, `subscription`
+  (entitlements/purchase info), `is_admin`, `is_active`, and the trial/
+  onboarding flags.
+
+## Writes
+
+### Feature config
+
+- **POST** `/api/features/config/` — create or update a user's feature config
+  (`update_or_create`, so it creates missing records). Resolve the user with
+  `user_id`/`username`/`email` (required — `404` if unresolved). Two body shapes:
+  ```json
+  // (a) bulk inline — set several features at once
+  { "user_id": "number | (username | email)", "platform_key": "string",
+    "config": { "feature_a": { "...": "any" }, "feature_b": true } }
+  ```
+  ```json
+  // (b) single feature — set one feature's values
+  { "username": "string | (user_id | email)", "platform_key": "string",
+    "feature": "string", "values": "any (object/bool/etc.)" }
+  ```
+  `200` on success; `400` if neither `config` nor (`feature` + `values`) is
+  given; `500` if the platform key doesn't resolve or the write fails. (`values`
+  must be present in the body for shape (b), even if `null`.)
+
+### Bulk config
+
+Apply a feature's `values` to **every existing** `UserFeatureConfig` record for
+a feature across one platform — a platform-wide overwrite. **Note: this will
+not create configs**, it only updates records that already exist.
+
+- **POST** `/api/features/bulk-config/` — bulk-update feature config across a
+  platform. Scope with `platform_key`. Same two mutually-exclusive body shapes
+  as above, **minus the user** (no user is resolved — it acts on all matching
+  records):
+  ```json
+  // (a) bulk inline
+  { "platform_key": "string", "config": { "feature_a": { "...": "any" } } }
+  ```
+  ```json
+  // (b) single feature
+  { "platform_key": "string", "feature": "string", "values": "any" }
+  ```
+  `200` on success; `400` if neither shape is given; `500` on failure.
+  Confirm with the user first (this rewrites values for every user on the
+  platform).
+
+### Apps & onboarding
+
+- **POST** `/api/features/apps/update/` — set the authenticated user's
+  onboarding status for one app. The user must already have access to the app
+  (`400` otherwise).
+  ```json
+  { "onboarding_completed": "boolean (required)",
+    "app": "string (required — app url, name, or id)" }
+  ```
+  Returns the serializer data (`200`), or `400` with validation errors.
+
+### Trial
+
+- **POST** `/api/features/apps/update-trial-status/` — activate (or set) the
+  authenticated user's free trial for an app. Only supported on the **main /
+  default platform** (`400` otherwise), and the user must have a platform link
+  for that platform (`400` otherwise; a `UserApp` is auto-created if missing).
+  ```json
+  { "app": "string (required — app url, name, or id)",
+    "platform": "string (required — the platform key)",
+    "free_trial_started": "boolean (default true)" }
+  ```
+  When `free_trial_started` is `true`, the trial is started **and marked
+  expired** for non-expired user-apps (one-shot activation). `200` on success.
+  Confirm with the user first (this consumes the user's free trial).
+
+### Provisioning
+
+**Gated by the `ENABLE_PLATFORM_PROVISIONING` setting** — when it is off (the
+default in some environments), this route is **not registered** and returns
+`404`. **Platform-admin only** (it uses the project's default DM-admin
+permission, unlike the open feature/app endpoints).
+
+- **POST** `/api/provision/{config_name}/` — run a stored
+  `PlatformProvisioningConfig` by its `name` (the `{config_name}` path slug;
+  `404` if no config with that name exists). The JSON request body is passed
+  through to the config's provisioning snippet as `request_data`. The snippet
+  is executed server-side and must produce a `result` mapping
+  (`{success, status_code, error_message?, data?}`), which becomes the
+  response; the config's status is recorded as `success` / `failed`.
+  Confirm with the user first (it executes a server-side provisioning routine
+  with side effects). Snippets defining the config are authored in Django admin,
+  not via this API.
+
+## Example
+
+Set a single feature's value for a user on your org's platform:
+
+```bash
+curl -X POST \
+  "https://api.iblai.app/dm/api/features/config/" \
+  -H "Authorization: Api-Token $IBLAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "username": "'"$IBLAI_USERNAME"'",
+        "platform_key": "'"$IBLAI_ORG"'",
+        "feature": "chat_ui",
+        "values": { "enabled": true, "theme": "dark" }
+      }'
+```
+
+Read it back:
+
+```bash
+curl -G \
+  "https://api.iblai.app/dm/api/features/config/" \
+  -H "Authorization: Api-Token $IBLAI_API_KEY" \
+  --data-urlencode "username=$IBLAI_USERNAME" \
+  --data-urlencode "platform_key=$IBLAI_ORG"
+```
+
+## Notes
+
+- **All endpoints are DM endpoints** under `https://api.iblai.app/dm`
+  (`/dm` + `/api/features/...` or `/api/provision/...`). Omitting `/dm` will not
+  resolve.
+- **Registered routes (exhaustive):** `GET|POST /api/features/config/`,
+  `POST /api/features/bulk-config/`, `GET /api/features/apps/`,
+  `POST /api/features/apps/update/`,
+  `POST /api/features/apps/update-trial-status/`, and (only when
+  `ENABLE_PLATFORM_PROVISIONING` is true) `POST /api/provision/{config_name}/`.
+  The `config` and `bulk-config` paths accept an optional trailing slash.
+- **Permissions.** The feature-config, bulk-config, apps, onboarding, and trial
+  views all set `permission_classes = []` (effectively **AllowAny** — the token
+  is still read for the apps/onboarding/trial views to identify the user). The
+  provisioning view sets no override, so it inherits the project default
+  (DM/platform-admin).
+- **Two body shapes** (`config` inline object vs `feature` + `values`) apply to
+  **both** `config/` and `bulk-config/` POSTs; `config/` additionally resolves
+  and requires a user, while `bulk-config/` operates platform-wide and creates
+  nothing.
+- **`apps/`, `apps/update/`, and `update-trial-status/` act on the
+  authenticated token's user** — there is no `user_id` parameter to target
+  another user. Use a token for the user you intend to modify.
+- **`app` is resolved flexibly** by url, name, or numeric id (`400` "App does
+  not exist" if none match) for the onboarding and trial endpoints.
+- The app also ships Django management commands (`seed_apps`,
+  `setup_features_tasks`) and an admin UI for authoring provisioning snippets;
+  those are server-side, not REST endpoints, and are out of scope here.

--- a/skills/iblai-integrations/SKILL.md
+++ b/skills/iblai-integrations/SKILL.md
@@ -18,7 +18,7 @@ providers or data sources, or issuing API keys.
 - Not connected yet? Run **`/iblai-login`** first to populate `IBLAI_ORG`,
   `IBLAI_USERNAME`, and `IBLAI_API_KEY`.
 
-## Reads & Writes
+## Reads
 
 ### LLMs
 
@@ -27,6 +27,27 @@ Third-party model provider keys. DM base: `/api/ai-account/…`.
 - **GET** `https://api.iblai.app/dm/api/ai-account/orgs/{org}/masked-llm-credential/` — list configured providers (masked).
 - **GET** `https://api.iblai.app/dm/api/ai-account/orgs/{org}/credential/schema/` — provider field schema.
 - **GET** `https://api.iblai.app/dm/api/ai-mentor/orgs/{org}/users/{username}/mentor/llms/` — available provider list.
+
+### Data Sources
+
+Data source provider credentials. DM base: `/api/ai-account/…`.
+
+- **GET** `https://api.iblai.app/dm/api/ai-account/orgs/{org}/masked-integration-credential/` — list configured data sources (masked).
+- **GET** `https://api.iblai.app/dm/api/ai-account/orgs/{org}/integration-credential/schema/v2/[?name=]` — provider field schema.
+
+### APIs
+
+Platform API keys. Same endpoints used to mint tokens elsewhere — see
+**`/iblai-tokens`** for the full reference.
+
+- **GET** `https://api.iblai.app/dm/api/core/platform/api-tokens/?platform_key={org}` — list tokens.
+
+## Writes
+
+### LLMs
+
+Third-party model provider keys. DM base: `/api/ai-account/…`.
+
 - **POST** `https://api.iblai.app/dm/api/ai-account/orgs/{org}/credential/` — add an LLM provider:
   ```json
   {
@@ -48,8 +69,6 @@ Third-party model provider keys. DM base: `/api/ai-account/…`.
 
 Data source provider credentials. DM base: `/api/ai-account/…`.
 
-- **GET** `https://api.iblai.app/dm/api/ai-account/orgs/{org}/masked-integration-credential/` — list configured data sources (masked).
-- **GET** `https://api.iblai.app/dm/api/ai-account/orgs/{org}/integration-credential/schema/v2/[?name=]` — provider field schema.
 - **POST** `https://api.iblai.app/dm/api/ai-account/orgs/{org}/integration-credential/` — add a data source:
   ```json
   {
@@ -71,7 +90,6 @@ Data source provider credentials. DM base: `/api/ai-account/…`.
 Platform API keys. Same endpoints used to mint tokens elsewhere — see
 **`/iblai-tokens`** for the full reference.
 
-- **GET** `https://api.iblai.app/dm/api/core/platform/api-tokens/?platform_key={org}` — list tokens.
 - **POST** `https://api.iblai.app/dm/api/core/platform/api-tokens/` — create a token:
   ```json
   {

--- a/skills/iblai-management/SKILL.md
+++ b/skills/iblai-management/SKILL.md
@@ -21,11 +21,45 @@ administration.
 - Not connected yet? Run **`/iblai-login`** first to populate `IBLAI_ORG`,
   `IBLAI_USERNAME`, and `IBLAI_API_KEY`.
 
-## Reads & Writes
+## Reads
 
 ### Users
 
 - **GET** `…/core/platform/users/?platform_key={org}&platform_org={org}&query={q}&page={n}&page_size=10&return_policies=true` — user list + policies.
+
+### Groups
+
+`…/core/rbac/groups/`
+
+- **GET** `…/groups/?platform_key={org}&include_users=true[&name=&email=&owner=&username=&page=&page_size=]` — list.
+- **GET** `…/groups/{id}/` — detail.
+
+### Roles
+
+`…/core/rbac/roles/` (all calls include `include_global_roles=true`)
+
+- **GET** `…/roles/?include_global_roles=true&platform_key={org}[&name=&page=&page_size=]` — list.
+- **GET** `…/roles/{id}/?include_global_roles=true&platform_key={org}` — detail.
+
+### Policies
+
+`…/core/rbac/policies/`
+
+- **GET** `…/policies/?platform_key={org}&include_groups=true&include_users=true[&role_id=&group=&name=&username=&email=&page=&page_size=]` — list.
+- **GET** `…/policies/{id}/?platform_key={org}` — detail.
+
+### Teams
+
+`…/core/user-groups/` plus team access (`…/core/rbac/teams/access/`)
+
+- **GET** `…/user-groups/?platform_key={org}[&include_users=&name=&with_permissions=&page=&page_size=]` — list.
+- **GET** `…/user-groups/{id}/?platform_key={org}` — detail.
+- **GET** `…/core/rbac/teams/access/?platform_key={org}&usergroup_id={id}` — list a team's access policies.
+
+## Writes
+
+### Users
+
 - **POST** `https://learn.iblai.app/api/ibl/users/manage/roles/` — promote/demote (LMS):
   ```json
   {
@@ -58,8 +92,6 @@ administration.
 
 `…/core/rbac/groups/`
 
-- **GET** `…/groups/?platform_key={org}&include_users=true[&name=&email=&owner=&username=&page=&page_size=]` — list.
-- **GET** `…/groups/{id}/` — detail.
 - **POST** `…/groups/` — create:
   ```json
   {
@@ -76,8 +108,6 @@ administration.
 
 `…/core/rbac/roles/` (all calls include `include_global_roles=true`)
 
-- **GET** `…/roles/?include_global_roles=true&platform_key={org}[&name=&page=&page_size=]` — list.
-- **GET** `…/roles/{id}/?include_global_roles=true&platform_key={org}` — detail.
 - **POST** `…/roles/?include_global_roles=true` — create:
   ```json
   {
@@ -94,8 +124,6 @@ administration.
 
 `…/core/rbac/policies/`
 
-- **GET** `…/policies/?platform_key={org}&include_groups=true&include_users=true[&role_id=&group=&name=&username=&email=&page=&page_size=]` — list.
-- **GET** `…/policies/{id}/?platform_key={org}` — detail.
 - **POST** `…/policies/` — create:
   ```json
   {
@@ -114,8 +142,6 @@ administration.
 
 `…/core/user-groups/` plus team access (`…/core/rbac/teams/access/`)
 
-- **GET** `…/user-groups/?platform_key={org}[&include_users=&name=&with_permissions=&page=&page_size=]` — list.
-- **GET** `…/user-groups/{id}/?platform_key={org}` — detail.
 - **POST** `…/user-groups/` — create:
   ```json
   {
@@ -127,7 +153,6 @@ administration.
   ```
 - **PUT** `…/user-groups/{id}/` — update (same shape).
 - **DELETE** `…/user-groups/{id}/` — delete. Destructive — confirm with the user first.
-- **GET** `…/core/rbac/teams/access/?platform_key={org}&usergroup_id={id}` — list a team's access policies.
 - **POST** `…/core/rbac/teams/access/` — set team access:
   ```json
   {

--- a/skills/iblai-milestones/SKILL.md
+++ b/skills/iblai-milestones/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: iblai-milestones
+description: Read and write an ibl.ai organization's catalog milestones via the platform API — course, resource, program, and pathway completions, plus skill points at block, course, platform, and user level (including bulk and group updates). Use when querying or recording learner progress and skill-point totals.
+---
+
+# iblai-milestones
+
+Read and write an organization's **catalog milestones**: completion records for
+courses, resources, programs, and pathways, and skill points scoped to a block,
+a course, the platform, or a user (with bulk and group updates). Use when
+querying or recording learner progress and skill-point totals.
+
+## Auth & conventions
+
+- **Base URL:** `https://api.iblai.app/dm` — these are Data Manager (DM)
+  endpoints, so the **`/dm` prefix is required**; the
+  `/api/catalog/milestones/…` paths below are appended to it (e.g.
+  `https://api.iblai.app/dm/api/catalog/milestones/completions/course/manage/`).
+- **Header:** `Authorization: Api-Token $IBLAI_API_KEY` on every request.
+- **Path vars:** `{org}` = `$IBLAI_ORG` (a.k.a. `platform_key`),
+  `{username}` = `$IBLAI_USERNAME`.
+- DELETE is destructive — **confirm with the user first.**
+- Not connected yet? Run **`/iblai-login`** first to populate `IBLAI_ORG`,
+  `IBLAI_USERNAME`, and `IBLAI_API_KEY`.
+
+## Reads
+
+### Completions
+
+#### Course
+
+- **GET** `/api/catalog/milestones/completions/course/manage/` — retrieve one course completion. Params: `course_id`, `user_id`. Returns `completion_percentage`, `completed`, `completion_date`, `completion_data`, grading fields.
+- **GET** `/api/catalog/milestones/completions/course/catalog/` — all course completions for one user, keyed by course id. Params: `user_id`; optional `field_key` (e.g. `completion_percentage`, `completion_data`) returns just that field per course.
+
+#### Resource
+
+- **GET** `/api/catalog/milestones/completions/resource/manage/` — retrieve one resource completion. Params: `resource_id`, `user_id`. Returns `resource_type`, `completion_percentage`, `completed`, `completion_data`.
+
+#### Program
+
+- **GET** `/api/catalog/milestones/completions/program/query/` — query a user's program completion. Params: `program_key` (required, urlencoded), and one of `user_id`/`username`. Returns `{ "count", "completion_percentage" }` (`completion_percentage` is 0.0–1.0).
+
+#### Pathway
+
+- **GET** `/api/catalog/milestones/completions/pathway/query/` — query a user's pathway completion. Params: `pathway_uuid` (required), and one of `user_id`/`username`. Returns `{ "count", "completion_percentage" }` (`completion_percentage` is 0.0–1.0).
+
+### Skill points
+
+#### Block
+
+- **GET** `/api/catalog/milestones/skill_points/block/` — skill points for a block. Param: `block_id` (URL-encoded). Returns a `{ skill: points }` map.
+
+#### Course
+
+- **GET** `/api/catalog/milestones/skill_points/course/` — skill points for a course. Param: `course_id` (URL-encoded). Returns a `{ skill: points }` map.
+
+#### Platform
+
+- **GET** `/api/catalog/milestones/skill_points/platform/` — list platform skill-point records. Params: `platform_key` (or `platform_org`) required; optional `query`, `sort` (default `-id`). Returns a paginated `{ count, next_page, previous_page, results[] }`, each result carrying `username`, `skill`, `skill_id`, `skill_points`.
+
+#### User
+
+- **GET** `/api/catalog/milestones/skill_points/user/` — aggregated skill points for one user. Params: `user_id`/`username`. Returns a `{ skill: { course_points, block_points, platform_points, total_points } }` map.
+
+## Writes
+
+### Completions
+
+#### Course
+
+- **POST** `/api/catalog/milestones/completions/course/manage/` — create/update a course completion. Body accepts `course_id`, `user_id`, and any `CourseCompletion` field:
+  ```json
+  { "course_id": "course-v1:edX+DemoX+Demo_Course", "user_id": 42, "completed": true, "completion_percentage": 95.3 }
+  ```
+
+#### Resource
+
+- **POST** `/api/catalog/milestones/completions/resource/manage/` — create/update a resource completion. Body: `resource_id` (int, required), `user_id` (int, required), optional `completed`, `completion_percentage` (0.0–1.0), `completion_date`, `completion_data`:
+  ```json
+  { "resource_id": 11, "user_id": 42, "completed": true, "completion_percentage": 1.0 }
+  ```
+
+### Skill points
+
+#### Block
+
+- **POST** `/api/catalog/milestones/skill_points/block/` — set a block's skill points:
+  ```json
+  { "block_id": "block-v1:test+test+test+type@html+block@2d68d2674abb47b5b676e822741acc25", "point_data": { "test-skill": 4.5, "another-skill": 6.2 } }
+  ```
+
+#### Course
+
+- **POST** `/api/catalog/milestones/skill_points/course/` — set a course's skill points:
+  ```json
+  { "course_id": "course-v1:test+test+test", "point_data": { "test-skill": 63.0, "another-skill": 45.0 } }
+  ```
+
+#### Platform
+
+- **POST** `/api/catalog/milestones/skill_points/platform/` — update a user's platform skill points. Body: `username`, `platform_key`, `point_data`, optional `overwrite` (default `true`):
+  ```json
+  { "username": "student1", "platform_key": "test-platform", "point_data": { "test-skill": 63.0, "another-skill": 45.0 }, "overwrite": false }
+  ```
+- **DELETE** `/api/catalog/milestones/skill_points/platform/` — delete one platform skill-point record. Params: `skill_point_id` (required), `platform_key` (or `platform_org`). Destructive — **confirm with the user first.**
+- **POST** `/api/catalog/milestones/skill_points/platform/bulk/` — bulk update platform skill points (platform-admin access). Body: `skill_point_data` (required; array of per-user entries — each entry takes `username`/`user_id`, `point_data`, optional `overwrite`), optional top-level `platform_key` applied to every entry:
+  ```json
+  { "platform_key": "test-platform", "skill_point_data": [ { "username": "student1", "point_data": { "test-skill": 63.0 }, "overwrite": false }, { "user_id": 7, "point_data": { "skill-1": 31.0 }, "overwrite": false } ] }
+  ```
+- **POST** `/api/catalog/milestones/skill_points/platform/group/` — update platform skill points for a group. Body: `group_id`, `platform_key`, `point_data`, optional `overwrite`:
+  ```json
+  { "group_id": 123, "platform_key": "test-platform", "point_data": { "test-skill": 63.0, "another-skill": 45.0 }, "overwrite": false }
+  ```
+
+## Example
+
+Look up a learner's course completion:
+
+```bash
+curl -G \
+  "https://api.iblai.app/dm/api/catalog/milestones/completions/course/manage/" \
+  -H "Authorization: Api-Token $IBLAI_API_KEY" \
+  --data-urlencode "course_id=course-v1:edX+DemoX+Demo_Course" \
+  --data-urlencode "user_id=10"
+```
+
+## Notes
+
+- **Id formats:** course ids are opaque keys like `course-v1:edX+DemoX+Demo_Course`;
+  block ids like `block-v1:test+test+test+type@html+block@<hash>`; program keys
+  like `program-v1:main+test`; pathways use a UUID (`pathway_uuid`). URL-encode
+  these in query strings (`:` → `%3A`, `+` → `%2B`, `@` → `%40`).
+- **`platform_key`** is the org key (`$IBLAI_ORG`) on the wire for skill-point
+  operations.
+- **`overwrite`** (default `true`) on platform/bulk/group updates replaces the
+  user's existing points for the given skills; set `false` to merge/add.
+- The course `catalog/` read returns *all* of a single user's course
+  completions at once; pass `field_key` to slice out one field per course.
+- Platform bulk updates require platform-admin level access.

--- a/skills/iblai-profile-metadata/SKILL.md
+++ b/skills/iblai-profile-metadata/SKILL.md
@@ -21,9 +21,21 @@ signed-in user; admins can target another user.
 - Not connected yet? Run **`/iblai-login`** first to populate `IBLAI_ORG`,
   `IBLAI_USERNAME`, and `IBLAI_API_KEY`.
 
-## Endpoints (all take `?platform_key={org}`; admins may add `&username={other_user}`)
+## Reads
+
+### Endpoints (all take `?platform_key={org}`; admins may add `&username={other_user}`)
 
 - **GET** `https://api.iblai.app/dm/api/core/users/platform-metadata/?platform_key={org}` — retrieve all metadata (defaults to the authenticated user).
+
+### Admin (target another user)
+
+- Append `&username={other_user}` to any of the above (admin only) to
+  read/update/replace/delete that user's metadata.
+
+## Writes
+
+### Endpoints (all take `?platform_key={org}`; admins may add `&username={other_user}`)
+
 - **PATCH** `https://api.iblai.app/dm/api/core/users/platform-metadata/?platform_key={org}` — update or delete specific keys without touching others (include at least one of `metadata` or `delete_keys`):
   ```json
   {
@@ -39,7 +51,7 @@ signed-in user; admins can target another user.
   ```
 - **DELETE** `https://api.iblai.app/dm/api/core/users/platform-metadata/?platform_key={org}` — clear all metadata for the user. Destructive — confirm with the user first.
 
-## Admin (target another user)
+### Admin (target another user)
 
 - Append `&username={other_user}` to any of the above (admin only) to
   read/update/replace/delete that user's metadata.

--- a/skills/iblai-profile/SKILL.md
+++ b/skills/iblai-profile/SKILL.md
@@ -20,44 +20,29 @@ side, use `/iblai-agent-memory`.)
 - Not connected yet? Run **`/iblai-login`** first to populate `IBLAI_ORG`,
   `IBLAI_USERNAME`, and `IBLAI_API_KEY`.
 
-## Basic & Social
+## Reads
+
+### Basic & Social
 
 Basic fields (full name, email, title, about, language) and social links are the
 user's account record.
 
 - **GET** `https://api.iblai.app/lms/api/user/v1/accounts/{username}` — account: `name`, `email`, `bio` (about text), `language_proficiencies`, `social_links`, profile image.
 - **GET** `https://api.iblai.app/lms/api/ibl/users/manage/metadata/?username={username}` — extended profile metadata (e.g. title).
-- **PATCH** `https://api.iblai.app/lms/api/user/v1/accounts/{username}` — update basic/social fields (`Content-Type: application/merge-patch+json`; send only changed keys):
-  ```json
-  {
-    "name": "string",
-    "bio": "string",
-    "language_proficiencies": [{ "code": "en" }],
-    "social_links": [{ "platform": "linkedin", "social_link": "https://…" }]
-  }
-  ```
 
-## Education
+### Education
 
 - **GET** `https://api.iblai.app/dm/api/career/orgs/{org}/education/users/{username}/` — list education records.
-- **POST** `…/dm/api/career/orgs/{org}/education/users/{username}/` — create an education entry.
-- **PUT** `…/dm/api/career/orgs/{org}/education/users/{username}/` — update an entry (body includes its `id`).
-- **GET / POST / PUT** `…/dm/api/career/orgs/{org}/institutions/users/{username}/` — institutions (the schools referenced by education records).
 
-## Experience
+### Experience
 
 - **GET** `https://api.iblai.app/dm/api/career/orgs/{org}/experience/users/{username}/` — list experience records.
-- **POST** `…/dm/api/career/orgs/{org}/experience/users/{username}/` — create an experience entry.
-- **PUT** `…/dm/api/career/orgs/{org}/experience/users/{username}/` — update an entry (body includes its `id`).
-- **GET / POST / PUT** `…/dm/api/career/orgs/{org}/companies/users/{username}/` — companies (the employers referenced by experience records).
 
-## Resume
+### Resume
 
 - **GET** `https://api.iblai.app/dm/api/career/resume/orgs/{org}/users/{username}/` — fetch resume + media files.
-- **POST** `…/dm/api/career/resume/orgs/{org}/users/{username}/` — upload a resume (`multipart/form-data`).
-- **PUT** `…/dm/api/career/resume/orgs/{org}/users/{username}/` — replace the resume (`multipart/form-data`).
 
-## Memory
+### Memory
 
 Memory covers two personalization flags plus the user's auto-extracted
 memories:
@@ -69,6 +54,38 @@ memories:
   These are the same memory objects the admin side manages; see
   **`/iblai-agent-memory`** for the memory CRUD endpoints
   (`…/mentors/{mentor}/mentor-memories/`), here scoped to the signed-in user.
+
+## Writes
+
+### Basic & Social
+
+- **PATCH** `https://api.iblai.app/lms/api/user/v1/accounts/{username}` — update basic/social fields (`Content-Type: application/merge-patch+json`; send only changed keys):
+  ```json
+  {
+    "name": "string",
+    "bio": "string",
+    "language_proficiencies": [{ "code": "en" }],
+    "social_links": [{ "platform": "linkedin", "social_link": "https://…" }]
+  }
+  ```
+
+### Education
+
+- **POST** `…/dm/api/career/orgs/{org}/education/users/{username}/` — create an education entry.
+- **PUT** `…/dm/api/career/orgs/{org}/education/users/{username}/` — update an entry (body includes its `id`).
+- **GET / POST / PUT** `…/dm/api/career/orgs/{org}/institutions/users/{username}/` — institutions (the schools referenced by education records).
+
+### Experience
+
+- **POST** `…/dm/api/career/orgs/{org}/experience/users/{username}/` — create an experience entry.
+- **PUT** `…/dm/api/career/orgs/{org}/experience/users/{username}/` — update an entry (body includes its `id`).
+- **GET / POST / PUT** `…/dm/api/career/orgs/{org}/companies/users/{username}/` — companies (the employers referenced by experience records).
+
+### Resume
+
+- **POST** `…/dm/api/career/resume/orgs/{org}/users/{username}/` — upload a resume (`multipart/form-data`).
+- **PUT** `…/dm/api/career/resume/orgs/{org}/users/{username}/` — replace the resume (`multipart/form-data`).
+
 ## Example
 
 Update the user's about text and add a LinkedIn social link:

--- a/skills/iblai-rbac/SKILL.md
+++ b/skills/iblai-rbac/SKILL.md
@@ -29,29 +29,55 @@ what" surface under `…/dm/api/core/rbac/…`.
 - There are **well-known roles** the platform ships with; list them with the
   roles endpoint (optionally including globals).
 
-## Roles
+## Reads
+
+### Roles
 
 - **GET** `https://api.iblai.app/dm/api/core/rbac/roles/?platform_key={org}` — list roles (add `&include_global_roles=true` to include globals).
-- **POST** `https://api.iblai.app/dm/api/core/rbac/roles/` — create a role.
 - **GET** `https://api.iblai.app/dm/api/core/rbac/roles/{id}/?platform_key={org}` — fetch one role.
+
+### Agent access
+
+- **GET** `https://api.iblai.app/dm/api/core/rbac/agent-access/?platform_key={org}&mentor_id={id}` — list an agent's access policies.
+
+### Policies
+
+- **GET** `https://api.iblai.app/dm/api/core/rbac/policies/{id}/?platform_key={org}` — fetch one policy.
+
+### Groups
+
+- **GET** `https://api.iblai.app/dm/api/core/rbac/groups/{id}/?platform_key={org}` — fetch one group.
+
+### Team (user-group) sharing
+
+- **GET** `https://api.iblai.app/dm/api/core/rbac/teams/access/?platform_key={org}&usergroup_id={id}` — list a team's access policies.
+
+### Student toggles
+
+- **GET** `https://api.iblai.app/dm/api/core/rbac/student-agent-creation/status/?platform_key={org}` — read the current toggle.
+- **GET** `https://api.iblai.app/dm/api/core/rbac/student-llm-access/status/?platform_key={org}` — read the current toggle.
+
+## Writes
+
+### Roles
+
+- **POST** `https://api.iblai.app/dm/api/core/rbac/roles/` — create a role.
 - **PUT / PATCH** `https://api.iblai.app/dm/api/core/rbac/roles/{id}/` — update a role.
 - **DELETE** `https://api.iblai.app/dm/api/core/rbac/roles/{id}/?platform_key={org}` — delete a role. Destructive — confirm with the user first.
 
-## Policies
+### Policies
 
 - **GET / POST** `https://api.iblai.app/dm/api/core/rbac/policies/?platform_key={org}` — list / create policies.
-- **GET** `https://api.iblai.app/dm/api/core/rbac/policies/{id}/?platform_key={org}` — fetch one policy.
 - **PUT / PATCH** `https://api.iblai.app/dm/api/core/rbac/policies/{id}/` — update a policy.
 - **DELETE** `https://api.iblai.app/dm/api/core/rbac/policies/{id}/?platform_key={org}` — delete a policy. Destructive — confirm with the user first.
 
-## Groups
+### Groups
 
 - **GET / POST** `https://api.iblai.app/dm/api/core/rbac/groups/?platform_key={org}` — list / create groups.
-- **GET** `https://api.iblai.app/dm/api/core/rbac/groups/{id}/?platform_key={org}` — fetch one group.
 - **PUT / PATCH** `https://api.iblai.app/dm/api/core/rbac/groups/{id}/` — update a group.
 - **DELETE** `https://api.iblai.app/dm/api/core/rbac/groups/{id}/?platform_key={org}` — delete a group. Destructive — confirm with the user first.
 
-## Permission check
+### Permission check
 
 - **POST** `https://api.iblai.app/dm/api/core/rbac/permissions/check/` — check the caller's access to resources:
   ```json
@@ -61,26 +87,22 @@ what" surface under `…/dm/api/core/rbac/…`.
   }
   ```
 
-## Agent access
+### Agent access
 
 - **POST** `https://api.iblai.app/dm/api/core/rbac/agent-access/` — share an agent (body includes `platform_key`, `mentor_id`, `role`, and `users`/`groups`).
-- **GET** `https://api.iblai.app/dm/api/core/rbac/agent-access/?platform_key={org}&mentor_id={id}` — list an agent's access policies.
 
-## Team (user-group) sharing
+### Team (user-group) sharing
 
 - **POST** `https://api.iblai.app/dm/api/core/rbac/teams/access/` — share a user-group (team).
-- **GET** `https://api.iblai.app/dm/api/core/rbac/teams/access/?platform_key={org}&usergroup_id={id}` — list a team's access policies.
 
-## Bulk user policies
+### Bulk user policies
 
 - **PUT** `https://api.iblai.app/dm/api/core/platform/users/policies/` — set policies for users (array).
 
-## Student toggles
+### Student toggles
 
 - **POST** `https://api.iblai.app/dm/api/core/rbac/student-agent-creation/set/` — enable/disable student agent creation.
-- **GET** `https://api.iblai.app/dm/api/core/rbac/student-agent-creation/status/?platform_key={org}` — read the current toggle.
 - **POST** `https://api.iblai.app/dm/api/core/rbac/student-llm-access/set/` — enable/disable student LLM access.
-- **GET** `https://api.iblai.app/dm/api/core/rbac/student-llm-access/status/?platform_key={org}` — read the current toggle.
 
 ## Example
 

--- a/skills/iblai-scim/SKILL.md
+++ b/skills/iblai-scim/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: iblai-scim
+description: Provision and manage an ibl.ai organization's directory over the SCIM 2.0 REST API — users (with the Enterprise User extension) and RBAC groups, including RBAC group membership that auto-links users to the platforms behind those groups. Use when standing up or syncing directory provisioning (SCIM 2.0) for an org: creating/deactivating users, managing RBAC group membership, or wiring identity-provider provisioning.
+---
+
+# iblai-scim
+
+Provision and manage an organization's **directory over the SCIM 2.0 REST API**:
+users (modeled on the SCIM User schema plus the Enterprise User extension) and
+**RBAC groups** (exposed via the SCIM Group schema), including RBAC group
+membership that automatically links users to the platforms behind those groups.
+Use when standing up or syncing directory provisioning for an org — creating or
+deactivating users, managing RBAC group membership, or wiring an identity
+provider's SCIM provisioning.
+
+> **Scope is exactly two resources: `Users` and `Groups`.** The SCIM app in the
+> DM service registers only these two — there are **no** Departments,
+> DepartmentMembers, or GroupMembers SCIM endpoints. (Departments and non-RBAC
+> groups still appear *inside* a user's Enterprise-extension response block, but
+> they are read-only there; there are no SCIM routes to manage them.)
+
+## Auth & conventions
+
+- **Base URL:** `https://api.iblai.app/dm` — these are Data Manager (DM)
+  endpoints, so the **`/dm` prefix is required**; the `/api/orgs/…/scim/v2/…`
+  paths below are appended to it (e.g.
+  `https://api.iblai.app/dm/api/orgs/{platform_key}/scim/v2/Users`).
+- **Header:** SCIM accepts **two** auth schemes (both authentication classes are
+  wired on every view: `PlatformApiKeyAuthentication`,
+  `OAuth2ClientCredentialAuthentication`):
+  - `Authorization: Api-Token $IBLAI_API_KEY` — the Platform API Token used by
+    the other `iblai-*` skills; or
+  - `Authorization: Bearer <oauth2-token>` — an OAuth2 client-credentials token.
+- **Content type:** send `Content-Type: application/scim+json` on every write
+  (the server also accepts plain `application/json`).
+- **Path / scope:** SCIM paths are `/api/orgs/{platform_key}/scim/v2/...` where
+  `{platform_key}` = `$IBLAI_ORG` (the org key). The token's scope must match the
+  `platform_key` in the URL.
+- **Resource casing — keep verbatim.** Both resources are **PascalCase**:
+  `Users` and `Groups`. Do not lowercase them.
+- **Trailing slash — keep verbatim.** Collection routes have **no** trailing
+  slash (`/Users`, `/Groups`); single-resource detail routes **require** a
+  trailing slash (`/Users/{id}/`, `/Groups/{id}/`). The group action routes
+  (`/Groups/{id}/add_members`, `/Groups/{id}/remove_members`) have **no** trailing
+  slash.
+- DELETE / destructive calls — **confirm with the user first.**
+- Not connected yet? Run **`/iblai-login`** first to populate `IBLAI_ORG`,
+  `IBLAI_USERNAME`, and `IBLAI_API_KEY`.
+
+## Reads
+
+### Users
+
+User resources use the SCIM core User schema
+(`urn:ietf:params:scim:schemas:core:2.0:User`) with the Enterprise User
+extension on responses
+(`urn:ietf:params:scim:schemas:extension:enterprise:2.0:User`).
+
+- **GET** `/api/orgs/{platform_key}/scim/v2/Users` — list users (filtering,
+  sorting, and pagination supported — see Notes).
+- **GET** `/api/orgs/{platform_key}/scim/v2/Users/{id}/` — retrieve one user.
+
+**Response — Enterprise extension.** The extension block is returned under the
+key `urn_ietf_params_scim_schemas_extension_enterprise_2_0_User` (underscores,
+not colons) and carries:
+
+- `edxData` — edX-specific user data.
+- `userData` — additional user metadata.
+- `departments` — departments the user belongs to (`id`, `name`, `$ref`, `isAdmin`).
+- `groups` — user-groups the user belongs to (`id`, `name`, `$ref`).
+- `rbacGroups` — RBAC groups (`id`, `uniqueId`, `name`, `description`, `platformKey`).
+- `platforms` — platforms the user can access (`id`, `key`, `name`, `org`).
+
+(On create/update/PATCH responses these lists are returned empty; the populated
+lists come back on GET list/retrieve.)
+
+### Groups (RBAC groups)
+
+The Group resource maps to the platform's **RBAC groups** and is exposed via the
+SCIM Group schema (`urn:ietf:params:scim:schemas:core:2.0:Group`). The SCIM `id`
+field is the RBAC group's **`unique_id`** (not a numeric id). These endpoints
+**manage existing RBAC groups only** — POST does not create a new group; if the
+referenced group's `unique_id` does not exist you get a `404` SCIM error.
+
+- **GET** `/api/orgs/{platform_key}/scim/v2/Groups` — list RBAC groups
+  (filtering supported; pass `excludedAttributes=members` to omit the member list).
+- **GET** `/api/orgs/{platform_key}/scim/v2/Groups/{id}/` — retrieve one RBAC
+  group by `unique_id`.
+
+## Writes
+
+### Users
+
+- **POST** `/api/orgs/{platform_key}/scim/v2/Users` — create (or, with
+  `"update": true`, modify an existing) user.
+- **PUT** `/api/orgs/{platform_key}/scim/v2/Users/{id}/` — replace a user's core
+  fields (`userName`, `name.formatted`, primary `emails` value, `active`); only
+  the fields present in the body are changed.
+- **PATCH** `/api/orgs/{platform_key}/scim/v2/Users/{id}/` — patch a user. Accepts
+  either a SCIM **PatchOp** body (`Operations` with `op`/`path`/`value`; supported
+  paths: `userName`, `name.formatted`, `emails[type eq "work"].value`, `active`,
+  `displayName`, and `externalId` — where `externalId` is treated as an RBAC group
+  `unique_id` to add the user to) **or** a plain partial body (`userName`, `name`,
+  `emails`, `active`, `displayName`).
+- **DELETE** `/api/orgs/{platform_key}/scim/v2/Users/{id}/` — **not supported**;
+  returns `405 Method Not Allowed`. (User deactivation is done by setting
+  `active: false`, not by DELETE.)
+
+Request body for POST (key attributes):
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+  "userName": "john.doe@example.com",
+  "name": { "formatted": "John Doe", "givenName": "John", "familyName": "Doe" },
+  "emails": [{ "value": "john.doe@example.com", "primary": true }],
+  "password": "securepassword123",
+  "provider": "google-oauth2",
+  "tpaUid": "john.doe@example.com",
+  "isStaff": false,
+  "active": true,
+  "update": false,
+  "platformOrgs": ["org1", "org2"],
+  "departmentIds": [1, 2, 3],
+  "groupIds": [1, 2, 3],
+  "rbacGroupUniqueIds": ["students", "course_123_enrolled"]
+}
+```
+
+Field notes: `userName` is the unique username/email (required); `emails` is
+required; `name` is required (may be partly blank); `password` / `provider` /
+`tpaUid` / `isStaff` are optional and forwarded to the LMS on create;
+`active` toggles account activation (set `false` to deactivate); `update: true`
+modifies an existing user instead of creating (skips the duplicate check);
+`platformOrgs` links the user to those org platforms; `departmentIds` /
+`groupIds` assign existing departments / user-groups by integer id (validated —
+unknown ids return `400`); `rbacGroupUniqueIds` assigns RBAC groups by unique id
+and auto-links the required platforms (see Notes). On a create that finds the
+user already exists, the API returns the existing user with HTTP `200` and still
+applies the link fields, rather than erroring.
+
+### Groups (RBAC groups)
+
+- **POST** `/api/orgs/{platform_key}/scim/v2/Groups` — manage an existing RBAC
+  group: optionally update its `displayName` / `description` and **set** its full
+  member list. The group is located by `id` (or `externalId`), both of which map
+  to the RBAC group's `unique_id`.
+
+  ```json
+  {
+    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+    "id": "students",
+    "displayName": "Students",
+    "description": "All enrolled students",
+    "members": [{ "value": "user-id-1", "display": "john.doe@example.com" }]
+  }
+  ```
+
+  `members[].value` is resolved as a user id, then username, then email; if no
+  user matches, one is created from the member data. The member list passed here
+  **replaces** the group's current membership.
+
+- **PUT** `/api/orgs/{platform_key}/scim/v2/Groups/{id}/` — update an existing RBAC
+  group's `displayName` / `description`, and (if `members` is present) **replace**
+  its complete member list (same body shape as POST, without needing `id` in the
+  body — the id comes from the URL).
+- **PATCH** `/api/orgs/{platform_key}/scim/v2/Groups/{id}/` — patch an RBAC group.
+  Accepts a SCIM **PatchOp** body whose `Operations` support
+  `replace` on `displayName` / `description` / `members` (replace whole list),
+  `add` on `members`, and `remove` with a `members[value eq "<user-id>"]` path —
+  **or** a plain partial body (`displayName`, `description`, `members`).
+- **POST** `/api/orgs/{platform_key}/scim/v2/Groups/{id}/add_members` — add members
+  via a SCIM PatchOp (only `op: add`, `path: members` operations are applied).
+
+  ```json
+  {
+    "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+    "Operations": [
+      { "op": "add", "path": "members",
+        "value": [{ "value": "user-id-3", "display": "bob.wilson@example.com" }] }
+    ]
+  }
+  ```
+
+- **POST** `/api/orgs/{platform_key}/scim/v2/Groups/{id}/remove_members` — remove
+  members via a SCIM PatchOp. Each operation must be `op: remove` with a path of
+  the form `members[value eq "<user-id>"]`.
+
+  ```json
+  {
+    "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+    "Operations": [
+      { "op": "remove", "path": "members[value eq \"user-id-1\"]" }
+    ]
+  }
+  ```
+
+- **DELETE** `/api/orgs/{platform_key}/scim/v2/Groups/{id}/` — hard-delete the RBAC
+  group (returns `204`). **Confirm with the user first.**
+
+## Example
+
+Create a SCIM user with RBAC groups (which auto-link the user's platforms):
+
+```bash
+curl -X POST \
+  "https://api.iblai.app/dm/api/orgs/$IBLAI_ORG/scim/v2/Users" \
+  -H "Authorization: Api-Token $IBLAI_API_KEY" \
+  -H "Content-Type: application/scim+json" \
+  -d '{
+    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+    "userName": "jane.smith@example.com",
+    "name": { "formatted": "Jane Smith", "givenName": "Jane", "familyName": "Smith" },
+    "emails": [{ "value": "jane.smith@example.com", "primary": true }],
+    "active": true,
+    "rbacGroupUniqueIds": ["students", "course_123_enrolled"]
+  }'
+```
+
+## Notes
+
+- **Error schema.** Group-not-found returns the SCIM error object:
+  `{"schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+  "scimType": "invalidValue", "detail": "..."}` with `404`. Other failures return
+  a plain `{"error": "..."}` body. Standard HTTP codes apply: `400`
+  invalid/missing fields (e.g. unknown `departmentIds` / `groupIds` /
+  `rbacGroupUniqueIds`), `401` missing/invalid auth, `404` not found, `405`
+  on `DELETE Users/{id}/`, `409` the user already exists on create (on a local
+  match the API instead returns the existing user with `200` — use `update: true`
+  to modify), `500` server error.
+- **Editing semantics.** **Users** are edited by re-POSTing with `update: true`,
+  or via `PUT Users/{id}/` / `PATCH Users/{id}/`. **Groups** are edited via
+  `PUT Groups/{id}/` (replaces the whole `members` list) or `PATCH Groups/{id}/`;
+  incremental membership changes go through the dedicated
+  `add_members` / `remove_members` actions, which take a **PatchOp** body
+  (`urn:ietf:params:scim:api:messages:2.0:PatchOp` with an `Operations` array of
+  `op` / `path` / `value`).
+- **RBAC group assignment auto-links platforms.** Assigning
+  `rbacGroupUniqueIds` on a user validates the groups exist, then automatically
+  creates platform links for any platforms behind those RBAC groups the user
+  isn't already linked to — so you can grant RBAC access without listing
+  `platformOrgs` explicitly. RBAC assignment runs after all other linking. Default
+  RBAC groups (server-configured) are applied to every user on platform link;
+  `rbacGroupUniqueIds` is additive on top of those.
+- **Group lookup is platform-scoped, with optional fallback.** Group lookups try
+  `(unique_id, platform_key)` first; if the server has strict platform matching
+  disabled, they fall back to matching `unique_id` on any platform.
+- **Filtering, sorting & pagination.** Both list endpoints accept SCIM `filter`
+  expressions (e.g. `userName eq "john.doe"`, `displayName eq "Students"`; user
+  filters support `userName`, `name.formatted`, `emails.value`, `active`, `id`,
+  `externalId`; group filters support `displayName`, `id`, `description`).
+  **`Users` list** also honors `startIndex` / `count` pagination (1-based;
+  defaults `startIndex=1`, `count=50`), `sortBy` (`userName`, `name.formatted`,
+  `active`) / `sortOrder` (`ascending` / `descending`), and `attributes` /
+  `excludedAttributes`. **`Groups` list** does **not** paginate (it returns all
+  matching groups) but does honor `excludedAttributes=members`.
+- **Enterprise extension key.** On responses the extension block's key uses
+  underscores — `urn_ietf_params_scim_schemas_extension_enterprise_2_0_User` —
+  not the colon-delimited URN.
+- **Schema reference.** Interactive SCIM API docs (drf-spectacular) are published
+  at `https://base.manager.iblai.tech/api-docs/#/scim`.
+</content>
+</invoke>

--- a/skills/iblai-search/SKILL.md
+++ b/skills/iblai-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: iblai-search
-description: Discover agents and learning content in an ibl.ai organization via the platform API — faceted, paginated search over agents and the catalog (courses, programs, pathways, skills), plus personalized (RAG) recommendations for the signed-in user. Use to find, browse, or get recommended agents/content. Read-only.
+description: Discover agents and learning content in an ibl.ai organization via the platform API — faceted, paginated search over agents and the catalog (courses, programs, pathways, skills), personalized (RAG) recommendations, global/personalized mentor search, and seller-facing sellable-items search; plus admin management of the recommendation prompts. Use to find, browse, or get recommended agents/content (mostly read-only; recommendation-prompt endpoints write).
 ---
 
 # iblai-search
@@ -9,18 +9,26 @@ Discover agents and learning content from the API in three ways: **agent**
 search (faceted, full-text search over agents), **content** search
 (faceted search over the catalog of courses, programs, pathways, and skills),
 and **recommendations** (personalized, RAG-ranked results for the signed-in
-user). All read-only. To *edit* an agent use the `/iblai-agent-*` skills.
+user) — plus a newer `/api/ai-search/...` family (global + personalized mentor
+search, sellable-items search, and admin recommendation-prompt management).
+Discovery is read-only; only the recommendation-prompt endpoints write. To
+*edit* an agent use the `/iblai-agent-*` skills.
 
 ## Auth & conventions
 
-- **Base URL:** `https://api.iblai.app`
+- **Base URL:** `https://api.iblai.app/dm` — these are Data Manager (DM)
+  endpoints, so the **`/dm` prefix is required**; the paths below are appended
+  to it (e.g. `https://api.iblai.app/dm/api/search/catalog/`).
 - **Header:** `Authorization: Api-Token $IBLAI_API_KEY` on every request.
 - **Path vars:** `{org}` = `$IBLAI_ORG`, `{username}` = `$IBLAI_USERNAME` (agent
-  search only; content search is not org-pathed — the org comes from the token).
+  search only; the `/api/ai-search/...` v2 endpoints and content search are
+  **not** org-pathed — the org/user come from the token or query params).
 - Not connected yet? Run **`/iblai-login`** first to populate `IBLAI_ORG`,
   `IBLAI_USERNAME`, and `IBLAI_API_KEY`.
 
-## Agent search
+## Reads
+
+### Agent search
 
 - **GET** `https://api.iblai.app/dm/api/search/orgs/{org}/users/{username}/mentors/` — search/browse agents. Query params:
   - `query` — full-text over name/description (e.g. `calculus`).
@@ -34,7 +42,7 @@ Each result has `unique_id`, `name`, `description`, `llm_provider`, `llm_name`,
 `profile_image`, `settings`. `facets` keys: Category, Created By, Featured, LLM
 Provider, Subject, Audience, Promotion, Recently Accessed.
 
-## Content search
+### Content search
 
 - **GET** `https://api.iblai.app/dm/api/search/catalog/` — search/browse the catalog. Query params:
   - `query` — full-text (e.g. `manufacturing`).
@@ -46,7 +54,7 @@ Provider, Subject, Audience, Promotion, Recently Accessed.
 **Envelope:** `{ results[], count, next, previous, current_page, total_pages, facets }`,
 where each result is `{ "type": "course|program|pathway|skill", "data": { } }`.
 
-## Recommendations
+### Recommendations
 
 Personalized, RAG-ranked results for the signed-in user. Unlike the two
 searches above, there is **no query**: results are computed server-side and are
@@ -58,6 +66,49 @@ user are derived from the token; this endpoint is not org-pathed.
   - `limit` — maximum number of recommendations.
 
 Returns a ranked list of the requested type. Call once per type for a mixed set.
+
+A newer `/api/ai-search/...` family (no org/user in the path — context comes from
+the token or query params). The `recommendations/` endpoint above is part of it.
+
+### Global mentor search
+
+- **GET** `https://api.iblai.app/dm/api/ai-search/mentors/` — global agent/mentor
+  search across the platform. Works **anonymously**; if a token is sent, results
+  are personalized to that user (pass `platform_key` for RBAC). Query params:
+  `query`, `platform_key`, facet filters mirroring the response, and
+  `limit`/`offset` pagination. Distinct from the org-pathed agent search above
+  (that one is tenant-scoped; this one is global).
+
+### Personalized mentors
+
+- **GET** `https://api.iblai.app/dm/api/ai-search/personalized-mentors/` —
+  personalized, mentor-focused results for the signed-in user (authentication
+  required). Pass `platform_key` (or `tenant`) and, where applicable, `username`.
+
+### Sellable items
+
+- **GET** `https://api.iblai.app/dm/api/ai-search/sellable-items/` — seller-facing
+  search over items that can be sold (for paywall/pricing setup). Requires an
+  authenticated user **with the `CanSellItems` RBAC permission**. Query params:
+  `platform_key`, `query`, item `type`, and pagination.
+
+### Recommendation prompts (admin)
+
+Manage the LLM prompt(s) that drive recommendations. **Platform-admin only.**
+
+- **GET** `https://api.iblai.app/dm/api/ai-search/recommendation/prompts/`
+  (preferred alias of `…/prompts/`) — list prompts. Params: `platform_key`,
+  `recommendation_type`, `active_only`, `prompt_id`.
+
+## Writes
+
+### Recommendation prompts
+
+Manage the LLM prompt(s) that drive recommendations. **Platform-admin only.**
+
+- **POST** `https://api.iblai.app/dm/api/ai-search/prompts/` — create a prompt. Confirm with the user first.
+- **PUT** `https://api.iblai.app/dm/api/ai-search/prompts/` — update a prompt (by `prompt_id`). Confirm with the user first.
+- **DELETE** `https://api.iblai.app/dm/api/ai-search/prompts/` — delete a prompt (by `prompt_id`). Confirm with the user first.
 
 ## Example
 
@@ -73,7 +124,9 @@ curl -s "https://api.iblai.app/dm/api/search/catalog/?query=manufacturing&limit=
 
 ## Notes
 
-- Read-only discovery — no writes on either surface.
+- Discovery (agent/content/recommendations/mentor/sellable-items search) is
+  read-only; the only writes are the admin **recommendation-prompt** endpoints
+  (`POST`/`PUT`/`DELETE …/ai-search/prompts/`).
 - The `facets` block in each response enumerates the available filter dimensions
   and counts; use its keys to drive additional filter params.
 - An agent result's `unique_id` is the `{mentor}` you pass to the


### PR DESCRIPTION
## What

Adds **8 new `iblai-*` skills** and standardizes the whole skills set, all derived **code-first** from the [`iblai/iblai-dm-pro`](https://github.com/iblai/iblai-dm-pro) URLconf (`urls.py`/views/serializers) — not the app `USAGE.md` docs, which proved unreliable.

### New skills (verified registered in the DM service, reached via `api.iblai.app/dm`)
- `iblai-catalog`, `iblai-milestones`, `iblai-credentials`, `iblai-scim`
- `iblai-billing`, `iblai-features`, `iblai-catalog-media`, `iblai-catalog-invitations`

Every endpoint was confirmed present in the repo's `urls.py` (app installed in `DM_APPS`, URLs auto-included via `EXTERNAL_APPS`). Excluded: edX-only `/api/ibl/...` paths, the not-installed `attendance` app, and the **deprecated** mentor-paywall (its documented paths aren't registered). Destructive/outward-facing calls are marked **"Confirm with the user first."**

### Other changes
- **iblai-search:** folded in verified v2 `/api/ai-search/...` routes (global + personalized mentor search, sellable-items, recommendation-prompt CRUD); fixed the read-only framing since prompt endpoints write.
- **iblai-crm:** corrected host to `https://api.iblai.app/dm` (off the legacy `platform.iblai.app`).
- **Format standardization:** every endpoint skill now follows `Auth & conventions → [optional explanatory] → Reads → Writes → Example → Notes`, with `###` resource sub-headings. `iblai-login`/`iblai-agent-chat` exempt (non-REST setup guides). Endpoint sets preserved verbatim (structural-only reorg).
- **CLAUDE.md:** documents the `/dm` + `/edx` gateway-prefix convention, the "only document endpoints registered in this repo's URLconf" rule, and the canonical section format.
- **README:** lists the new skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)