### PR TITLE
docs: simplify login onboarding to two clear paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,20 @@ npx skills add iblai/api
 
 This installs skills that teach your AI agent how to **drive the ibl.ai platform REST API directly** — configure agents, manage datasets and memory, administer users and roles, send notifications, and pull analytics — for any organization you belong to. You'll now have the `/iblai-*` commands in your agent.
 
-### 2. Connect an organization
+### 2. Get signed in
 
-Run the login skill once. It opens [login.iblai.app/me](https://login.iblai.app/me), you sign in via SSO, it asks which of your organizations to use, and it writes your **org key**, **username**, and a **Platform API Token** to `.env`:
+You need an ibl.ai account with your own organization. Two ways in:
+
+- **No account (or no org of your own)?** Go to **[ibl.ai/join](https://ibl.ai/join)**. Signing up creates your account *and* your organization and leaves you logged in — that's everything you need.
+- **Already have an account?** Sign in at **[login.iblai.app/me](https://login.iblai.app/me)**.
+
+### 3. Connect it
+
+Run the login skill once. It reads your signed-in session from `login.iblai.app/me`, asks which organization to use, and writes your **org key**, **username**, and a **Platform API Token** to `.env`:
 
 ```text
 /iblai-login
 ```
-
-> **First time?** No ibl.ai account → start at [ibl.ai/join](https://ibl.ai/join) (it leads you through creating your organization), then run `/iblai-login`. Already signed in but only see the shared **`main`** organization? That's not your own workspace — create your own org first; `/iblai-login` handles it.
 
 Every other skill then reads `IBLAI_ORG`, `IBLAI_USERNAME`, and `IBLAI_API_KEY` from `.env` and calls `https://api.iblai.app` with `Authorization: Api-Token <key>`.
 
@@ -208,9 +213,9 @@ Everything authenticates the same way:
 - **Base URL:** `https://api.iblai.app`
 - **Header:** `Authorization: Api-Token <key>` on every request
 - **Org & username:** from [login.iblai.app/me](https://login.iblai.app/me) — each organization you belong to shows its **key** (e.g. `enterprise`, `iblai`, or a UUID)
-- **Api-Token:** your **first** token comes from the platform admin (or `login.iblai.app`); once you're connected, `/iblai-tokens` lists, creates, and rotates tokens. The secret is shown once.
+- **Api-Token:** `/iblai-login` mints your first token from your signed-in session; afterward `/iblai-tokens` lists, creates, and rotates tokens. The secret is shown once.
 
-The `/iblai-login` skill walks through all of this and writes `IBLAI_ORG`, `IBLAI_USERNAME`, and `IBLAI_API_KEY` to `.env`. Never commit `.env` — it is in `.gitignore`.
+`/iblai-login` does all of this for you — get signed in (via [ibl.ai/join](https://ibl.ai/join) if you're new, or [login.iblai.app/me](https://login.iblai.app/me) if you have an account), then run it and it writes `IBLAI_ORG`, `IBLAI_USERNAME`, and `IBLAI_API_KEY` to `.env`. Never commit `.env` — it is in `.gitignore`.
 
 ## Resources
 

--- a/skills/iblai-login/SKILL.md
+++ b/skills/iblai-login/SKILL.md
@@ -1,91 +1,73 @@
 ---
 name: iblai-login
-description: Connect an ibl.ai organization for API access. Opens login.iblai.app/me in the browser so the user signs in via SSO, captures their org key and username, helps mint a Platform API Token, and writes IBLAI_ORG / IBLAI_USERNAME / IBLAI_API_KEY to .env. Run this first before any other iblai-* skill.
+description: Connect an ibl.ai organization for API access. Gets the user signed in (ibl.ai/join if new, login.iblai.app/me if returning), captures their org key and username, mints a Platform API Token, and writes IBLAI_ORG / IBLAI_USERNAME / IBLAI_API_KEY to .env. Run this first before any other iblai-* skill.
 ---
 
 # iblai-login
 
 Connect an organization so the other `iblai-*` skills can call the ibl.ai platform.
 Every API call needs three things — your **org key**, your **username**, and a
-**Platform API Token** — and this skill collects all three from
-[login.iblai.app/me](https://login.iblai.app/me) and writes them to `.env`.
-
-Run this once per organization. After it succeeds, every other skill reads the values
-from `.env`.
+**Platform API Token** — and this skill collects all three and writes them to
+`.env`. Run it once per organization.
 
 ## What you are collecting
 
-| Value             | Goes in `.env` as    | Where it comes from                                   |
-| ----------------- | -------------------- | ----------------------------------------------------- |
-| Org key  | `IBLAI_ORG`          | `login.iblai.app/me` → the **key** of the chosen org  |
-| Username          | `IBLAI_USERNAME`     | `login.iblai.app/me` → account / profile              |
-| Platform API Token| `IBLAI_API_KEY`      | An Api-Token minted for the org — see step 3          |
+| Value              | Goes in `.env` as | Where it comes from                                  |
+| ------------------ | ----------------- | ---------------------------------------------------- |
+| Org key            | `IBLAI_ORG`       | `login.iblai.app/me` → the **key** of the chosen org |
+| Username           | `IBLAI_USERNAME`  | `login.iblai.app/me` → account / profile             |
+| Platform API Token | `IBLAI_API_KEY`   | An Api-Token minted from the session — see step 2    |
 
 The base URL is fixed: `https://api.iblai.app`. Auth header on every request is
 `Authorization: Api-Token <IBLAI_API_KEY>`.
 
-## Steps
+## Get the user signed in
+
+This skill needs a signed-in `login.iblai.app/me` session. Two paths:
+
+- **No account, or no org of their own?** Send them to **https://ibl.ai/join**.
+  Signing up creates their account **and** their organization and leaves them
+  logged in — that's everything this skill needs. (This also covers the user who
+  only sees the shared **`main`** org: `main` is the default everyone lands in,
+  not their own workspace, so they still need to join/create one.)
+- **Already have an account?** Have them sign in at **https://login.iblai.app/me**.
+
+Never enter the user's credentials for them — let them complete the login, then
+read the values off the page.
 
 > **Tip — use browser automation.** This skill is smoothest when the agent can
-> drive a browser (e.g. the user launches **`claude --chrome`**): it can open
-> `login.iblai.app/me`, read the signed-in session, and **mint the API token
-> automatically** (step 3). Without a browser you'll walk the user through the
-> page and they paste a token instead — recommend they relaunch with
+> drive a browser (e.g. the user launches **`claude --chrome`**): it can read the
+> signed-in session and **mint the API token automatically** (step 2). Without a
+> browser, the user pastes a token instead — recommend they relaunch with
 > `claude --chrome` for the automated path.
 
-1. **Open the account page in the browser.**
+## Steps
 
-   Navigate the user to **https://login.iblai.app/me**.
+1. **Read the org key and username off `/me`.**
 
-   **If the user is not logged in** (the page redirects to a sign-in screen
-   instead of showing "My Account"), do not try to authenticate for them. Print
-   the login URL and ask them to sign in, then continue once they confirm:
+   Navigate to **https://login.iblai.app/me**. If it redirects to a sign-in
+   screen, the user isn't logged in — point them at the paths above and wait for
+   them to confirm. **After login the platform redirects elsewhere (the
+   destination varies), not back to `/me`** — so always **re-navigate explicitly
+   to `https://login.iblai.app/me`** before reading.
 
-   > You are not signed in to ibl.ai. Open this URL, log in (email, Apple,
-   > Google, or password — SSO/OAuth/OIDC/SAML where your org configures it),
-   > then tell me when you are done:
-   >
-   > **https://login.iblai.app/me**
+   `/me` is server-rendered (no JSON API), so read the values off the **rendered
+   page content**. It shows the account (username/email) and the list of
+   organizations the user belongs to; each org block is the display name followed
+   by its **key** — e.g. `enterprise`, a company slug, or a UUID like
+   `3b42a400a2fc4ec9…`. Accounts can belong to many orgs (40+ is normal), so
+   **always ask the user which org to target** → `IBLAI_ORG`, and capture the
+   account username → `IBLAI_USERNAME`.
 
-   Wait for the user to confirm they have logged in. **After login the platform
-   redirects somewhere else (the destination varies and may change), not back to
-   `/me`** — so always **re-navigate explicitly to `https://login.iblai.app/me`**
-   before reading. Do not assume you are already on `/me`; the only thing that
-   matters is that once signed in you can reach `login.iblai.app/me`.
+2. **Mint a Platform API Token from the session.**
 
-   > Do not enter the user's credentials for them — let them complete the login
-   > themselves. Only read the values off the page once they are signed in.
+   API calls authenticate with an **Api-Token**, not the browser login.
 
-2. **Read the org key and username off `/me`.**
-
-   `/me` is server-rendered (no separate JSON API to call), so read the values
-   off the **rendered page content**. It shows the account (username/email) and
-   the list of organizations the user belongs to; each org block is the display
-   name followed by its **key** — e.g. `enterprise`, `main`, a company slug, or a
-   UUID like `3b42a400a2fc4ec9...`. Accounts can belong to many orgs (40+ is
-   normal), so **always ask the user which org to target** rather than picking
-   one — capture that org key → `IBLAI_ORG`, and the account username →
-   `IBLAI_USERNAME`.
-
-   **If the only org is `main`:** `main` is the shared default everyone lands in
-   — it is *not* the user's own workspace. If `/me` shows only `main`, the user
-   must **create their own organization** before continuing.
-   > Org-creation endpoint: _to be added._ Until then, direct the user to create
-   > an organization (in the platform / at `login.iblai.app`), then re-read `/me`
-   > and pick the new org.
-
-3. **Mint a Platform API Token from the session.**
-
-   API calls authenticate with an **Api-Token**, not the browser login. Create
-   one for the chosen org:
-
-   - **With browser automation (recommended):** once the user is signed in on
-     `login.iblai.app/me`, the page's session carries a short-lived auth token —
-     read **`dm_token`** from that site's `localStorage`. Use it with the
-     **`Token`** auth scheme (**not** `Bearer` — `Bearer` returns `401
-     Authentication credentials were not provided`) to create a Platform API
-     Token (the same `POST …/platform/api-tokens/` call documented in
-     **`/iblai-tokens`**):
+   - **With browser automation (recommended):** the signed-in `login.iblai.app`
+     session carries a short-lived auth token in `localStorage` as **`dm_token`**.
+     Use it with the **`Token`** scheme (**not** `Bearer` — `Bearer` returns
+     `401`) to create a Platform API Token (the same `POST …/platform/api-tokens/`
+     call documented in **`/iblai-tokens`**):
 
      ```http
      POST https://api.iblai.app/dm/api/core/platform/api-tokens/
@@ -98,38 +80,23 @@ The base URL is fixed: `https://api.iblai.app`. Auth header on every request is
 
      Capture the returned secret (shown once) → `IBLAI_API_KEY`.
 
-     > **Token uniqueness:** `(platform_key, name)` must be unique. Re-running
-     > with the same `name` for an org returns `400 … must make a unique set`.
-     > Use a fresh `name` (e.g. `iblai-cli-<org>`) or reuse the existing token.
+     > **Token uniqueness:** `(platform_key, name)` must be unique. Re-running with
+     > the same `name` for an org returns `400 … must make a unique set` — use a
+     > fresh `name` (e.g. `iblai-cli-<org>`) or reuse the existing token.
 
-     > **Which tenant the token targets.** The **`platform_key` in the request
-     > body** is what scopes the resulting token — an admin's `dm_token` can mint
-     > a token for any org they administer, regardless of which tenant the
-     > browser session is currently "in". The `dm_token` itself, however, **is
-     > tenant-scoped**: switching the active tenant rotates it. So if minting
-     > fails with a `401`/`403` (the session lacks rights on the target org),
-     > switch the active tenant first, then re-read `dm_token` and retry:
-     > open **os.ibl.ai**, use the **org dropdown at the top-right**, scroll to
-     > the target tenant and select it (the URL becomes
-     > `os.ibl.ai/platform/<org>/…`), then read the refreshed `dm_token` from
-     > that page's `localStorage`.
+     > **Which org the token targets.** The **`platform_key` in the request body**
+     > scopes the resulting token — an admin's `dm_token` can mint a token for any
+     > org they administer. The `dm_token` itself is tenant-scoped, though, so if
+     > minting fails with `401`/`403`, switch the active tenant and re-read it:
+     > open **os.ibl.ai**, use the **org dropdown (top-right)**, select the target
+     > org (URL becomes `os.ibl.ai/platform/<org>/…`), then read the refreshed
+     > `dm_token` from that page's `localStorage`.
 
-     > **Verifying the minted token.** Do **not** verify an `Api-Token` against
-     > the `…/platform/api-tokens/` management endpoint — that endpoint only
-     > accepts the session `Token <dm_token>` scheme and returns `401` for *any*
-     > `Api-Token`, valid or not. Verify against a real data endpoint instead,
-     > e.g. `GET …/platform/users/?platform_key=<org>&platform_org=<org>` with
-     > `Authorization: Api-Token <key>` → `200`.
+   - **Without a browser:** have the user create a token in the platform admin (or
+     at `login.iblai.app`) and paste the secret. Recommend `claude --chrome` to
+     automate this.
 
-   - **Without a browser:** have the user create a token in the platform admin
-     (or at `login.iblai.app`) and paste the secret. You can recommend they
-     relaunch with `claude --chrome` to automate this.
-
-   Capture the token → `IBLAI_API_KEY`.
-
-4. **Save to `.env` (and make sure it's gitignored).**
-
-   Once you have the org key + token, create/update `.env` at the project root:
+3. **Save to `.env` (and make sure it's gitignored).**
 
    ```dotenv
    IBLAI_ORG=<org key>
@@ -138,20 +105,20 @@ The base URL is fixed: `https://api.iblai.app`. Auth header on every request is
    ```
 
    **Before writing it, guarantee `.env` is ignored by git** — check `.gitignore`
-   and add a `.env` line if it is not already there, so the token can never be
-   committed. Create `.gitignore` with that line if the project has none.
+   and add a `.env` line if missing (create `.gitignore` if the project has none),
+   so the token can never be committed.
 
    Every other `iblai-*` skill reads these values. To make them live in shell
    commands, `source .env` (`set -a; . ./.env; set +a`) before API calls — or, in
    Claude Code, mirror them into `.claude/settings.local.json` `env` (also
    gitignored) for automatic injection.
 
-5. **Verify the connection.**
+4. **Verify the connection.**
 
    Confirm the token authenticates against a real data endpoint. Do **not** use
-   the `…/platform/api-tokens/` management endpoint here — it only accepts the
-   session `Token <dm_token>` scheme and returns `401` for *any* `Api-Token`,
-   so it cannot confirm a minted token works:
+   the `…/platform/api-tokens/` management endpoint — it only accepts the session
+   `Token <dm_token>` scheme and returns `401` for *any* `Api-Token`, valid or
+   not, so it cannot confirm a minted token works:
 
    ```bash
    curl -s -o /dev/null -w '%{http_code}\n' \
@@ -167,9 +134,5 @@ The base URL is fixed: `https://api.iblai.app`. Auth header on every request is
 - `{org}` (a.k.a. `platform_key`), `{username}`, and `{mentor}` (agent unique id,
   e.g. `d17dc729-60fd-4363-81a0-f67d9318b03e`) are the path variables every other
   skill substitutes.
-- One organization = one org key + one Api-Token. To switch organizations, re-run this skill
-  and pick a different org on `/me`.
-- If the user has **no account**, send them to https://ibl.ai/join to sign up —
-  that flow leads them through creating their own organization — then restart
-  this skill. (An existing account that only has the shared `main` org still
-  needs its own org created; see step 2.)
+- One organization = one org key + one Api-Token. To switch organizations, re-run
+  this skill and pick a different org on `/me`.


### PR DESCRIPTION
Simplifies how the README and `/iblai-login` skill explain getting connected, leading with the front door instead of the token-minting mechanics.

## The two paths
- **No account (or no org of your own)?** → [ibl.ai/join](https://ibl.ai/join) creates your account *and* org and leaves you logged in.
- **Already have an account?** → sign in at [login.iblai.app/me](https://login.iblai.app/me).

Then `/iblai-login` captures org key + username + a minted Platform API Token into `.env`.

## Changes
- **README** — Quick Start split into **2. Get signed in** (two paths) → **3. Connect it**; dropped the scattered "first-time / only-`main`-org" asides; tightened the Authentication section.
- **iblai-login skill** — new up-front "Get the user signed in" section consolidating the no-account / `main`-only / org-creation handling; collapsed 5 steps to 4.
- **Kept intact** the code-verified token-minting technicals: `dm_token` from localStorage, `Token` scheme (not `Bearer`), `(platform_key, name)` uniqueness, tenant-scope/`os.ibl.ai` switch, and verifying against `…/platform/users/`.

No code or endpoints changed — docs/prose only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)