### PR TITLE
docs(login): document org key + secret as a no-browser auth path

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Run the login skill once. It reads your signed-in session from `login.iblai.app/
 
 Every other skill then reads `IBLAI_ORG`, `IBLAI_USERNAME`, and `IBLAI_API_KEY` from `.env` and calls `https://api.iblai.app` with `Authorization: Api-Token <key>`.
 
+> **Headless / CI? Already have org credentials (key + secret)?** Skip the browser. An **org secret** works directly as the Api-Token — set `IBLAI_ORG=<org key>` and `IBLAI_API_KEY=<org secret>`, then read `IBLAI_USERNAME` from the API (an `is_admin` user on the org). `/iblai-login` documents this path under [Fastest path — org credentials](skills/iblai-login/SKILL.md).
+
 ## What is iblai/api
 
 A toolkit for operating the [ibl.ai](https://ibl.ai) platform from your AI agent. Where [`iblai/vibe`](https://github.com/iblai/vibe) gives you UI components to *build* an app, `iblai/api` gives you skills to *run the platform itself* — every agent-configuration and platform-admin operation mapped to its exact REST endpoints (method, URL, body) — plus a hosted MCP server for the one runtime capability that isn't a REST call: chatting with a deployed agent.
@@ -248,6 +250,7 @@ Everything authenticates the same way:
 - **Header:** `Authorization: Api-Token <key>` on every request
 - **Org & username:** from [login.iblai.app/me](https://login.iblai.app/me) — each organization you belong to shows its **key** (e.g. `enterprise`, `iblai`, or a UUID)
 - **Api-Token:** `/iblai-login` mints your first token from your signed-in session; afterward `/iblai-tokens` lists, creates, and rotates tokens. The secret is shown once.
+- **Org credentials (key + secret):** for headless/CI use, an org **secret** is itself a valid Api-Token — set `IBLAI_API_KEY=<org secret>` and `IBLAI_ORG=<org key>` with no browser step. See [Fastest path — org credentials](skills/iblai-login/SKILL.md).
 
 `/iblai-login` does all of this for you — get signed in (via [ibl.ai/join](https://ibl.ai/join) if you're new, or [login.iblai.app/me](https://login.iblai.app/me) if you have an account), then run it and it writes `IBLAI_ORG`, `IBLAI_USERNAME`, and `IBLAI_API_KEY` to `.env`. Never commit `.env` — it is in `.gitignore`.
 

--- a/skills/iblai-login/SKILL.md
+++ b/skills/iblai-login/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: iblai-login
-description: Connect an ibl.ai organization for API access. Gets the user signed in (ibl.ai/join if new, login.iblai.app/me if returning), captures their org key and username, mints a Platform API Token, and writes IBLAI_ORG / IBLAI_USERNAME / IBLAI_API_KEY to .env. Run this first before any other iblai-* skill.
+description: Connect an ibl.ai organization for API access. Gets the user signed in (ibl.ai/join if new, login.iblai.app/me if returning), captures their org key and username, mints a Platform API Token, and writes IBLAI_ORG / IBLAI_USERNAME / IBLAI_API_KEY to .env. If you already hold org credentials (key + secret), the secret works directly as the Api-Token — no browser needed. Run this first before any other iblai-* skill.
 ---
 
 # iblai-login
@@ -20,6 +20,33 @@ Every API call needs three things — your **org key**, your **username**, and a
 
 The base URL is fixed: `https://api.iblai.app`. Auth header on every request is
 `Authorization: Api-Token <IBLAI_API_KEY>`.
+
+## Fastest path — org credentials (key + secret)
+
+If you already hold **organization credentials** — an **org key** and an **org
+secret** (issued for the org for automation/CI; the same pair the ibl.ai
+quickstarts use) — you can skip the browser entirely. The **org secret works
+directly as the Platform API Token**; there is nothing to mint:
+
+```dotenv
+IBLAI_ORG=<org key>          # e.g. acme
+IBLAI_API_KEY=<org secret>   # used verbatim as: Authorization: Api-Token <secret>
+```
+
+The only value left is `IBLAI_USERNAME`. Read an admin username straight from the
+API with the two values above — no `/me` page needed:
+
+```bash
+set -a; . ./.env; set +a
+curl -s "https://api.iblai.app/dm/api/core/platform/users/?platform_key=$IBLAI_ORG&platform_org=$IBLAI_ORG&page=1&page_size=5" \
+  -H "Authorization: Api-Token $IBLAI_API_KEY" \
+  | python3 -c "import sys,json;[print(u['username'], u.get('is_admin')) for u in json.load(sys.stdin)['results']]"
+# pick an is_admin=True username → IBLAI_USERNAME
+```
+
+Then skip to **step 3** (save to `.env`) and **step 4** (verify). The
+browser-session flow below is only for when you *don't* have org credentials and
+must mint a token from a signed-in session.
 
 ## Get the user signed in
 
@@ -92,9 +119,12 @@ read the values off the page.
      > org (URL becomes `os.ibl.ai/platform/<org>/…`), then read the refreshed
      > `dm_token` from that page's `localStorage`.
 
-   - **Without a browser:** have the user create a token in the platform admin (or
-     at `login.iblai.app`) and paste the secret. Recommend `claude --chrome` to
-     automate this.
+   - **Without a browser:** if you have **org credentials (key + secret)**, skip
+     this step entirely — the org secret *is* the `IBLAI_API_KEY` (see
+     [Fastest path — org credentials](#fastest-path--org-credentials-key--secret)
+     above). Otherwise, have the user create a token in the platform admin (or at
+     `login.iblai.app`) and paste the secret; recommend `claude --chrome` to
+     automate it.
 
 3. **Save to `.env` (and make sure it's gitignored).**
 


### PR DESCRIPTION
## Problem

The `iblai-login` skill (and the README) only document a **browser-session** flow for obtaining an Api-Token: sign in at `login.iblai.app/me`, read `dm_token` from `localStorage`, and mint a Platform API Token. Anyone who installs these skills with **organization credentials already in hand** — an **org key + org secret** (the kind provisioned for CI/automation, and what the [ibl.ai quickstarts](https://github.com/iblai/quickstarts) use) — hits a wall, because nothing tells them those credentials are enough.

They are. The **org secret works directly as the Api-Token**:

```bash
curl -s -o /dev/null -w '%{http_code}\n' \
  "https://api.iblai.app/dm/api/core/platform/users/?platform_key=<org>&platform_org=<org>&page=1&page_size=1" \
  -H "Authorization: Api-Token <org secret>"
# => 200
```

So `IBLAI_ORG=<org key>` + `IBLAI_API_KEY=<org secret>` authenticates every `iblai-*` skill with no browser step, and `IBLAI_USERNAME` can be read straight from the platform users endpoint (pick an `is_admin` user).

## Change

Docs only — no behavior change:

- **`skills/iblai-login/SKILL.md`** — adds a **"Fastest path — org credentials (key + secret)"** section, points the existing *"Without a browser"* step at it, and notes it in the frontmatter description.
- **`README.md`** — adds the org-credentials path to both auth sections.

## Why

So the next person who installs these skills with org credentials isn't blocked guessing at the auth header — which is exactly what happened on a real setup.