### PR TITLE
docs(iblai-agent-mcp): add connector model, resolution order & in-chat OAuth

### DIFF
--- a/skills/iblai-agent-mcp/SKILL.md
+++ b/skills/iblai-agent-mcp/SKILL.md
@@ -83,6 +83,65 @@ curl -X POST \
   }'
 ```
 
+## Connector model
+
+Three objects work together:
+
+- **MCP server** (`mcp-servers/`) — the connector record: `name`, `url`,
+  `transport` (`sse|websocket|streamable_http`), `auth_type`
+  (`none|token|oauth2`), and `auth_scope` (`user|mentor|tenant`).
+  `is_featured=true` lets admins in *other* orgs create their own connections to
+  the same server; disabled connectors are skipped at runtime.
+- **MCP server connection** (`mcp-server-connections/`) — the auth binding that
+  supplies credentials for a server at a given `scope`. OAuth2 connections
+  reference a `connected_service`.
+- **Connected service** (`connected-services/…`) — a user's stored OAuth grant
+  for a provider + service (e.g. `google` + `drive`), created by completing the
+  OAuth flow. One per user per service.
+
+`auth_type` and `auth_scope` answer two different questions: `auth_type` is
+*how* the call is authenticated (`none`, a static `token`, or `oauth2`);
+`auth_scope`/`scope` is *whose* credentials are used (`user`, `mentor`, or
+`tenant`). Only `auth_type=oauth2` **and** `auth_scope=user` together trigger the
+in-chat OAuth prompt below.
+
+## Runtime credential resolution
+
+When an agent calls an attached MCP server, the platform selects credentials in
+priority order — first match wins:
+
+1. **user**-scoped connection for (server, current user)
+2. **mentor**-scoped connection for (server, agent)
+3. **tenant**-scoped connection for (server, org)
+4. featured-server global fallback
+5. otherwise fail (401 / no connection) — or, for a per-user oauth2 server with
+   no user connection, start the in-chat OAuth flow
+
+OAuth access tokens are refreshed automatically as they near expiry — no client
+action required.
+
+## In-chat OAuth (per-user oauth2 connectors)
+
+A connector with `auth_type=oauth2` + `auth_scope=user` authenticates each user
+individually. When an authenticated user chats with the agent and has no
+connection yet, the chat pauses and the runtime emits JSON events on the
+existing chat socket (WebSocket/SSE) — switch on the `type` field:
+
+- `oauth_required` — carries `server_name`, `server_id`, and `auth_url`; open
+  `auth_url` in a new tab/popup (providers block iframes) so the user can
+  authenticate. Backend then polls for the new connection.
+- `oauth_connection_resolved` — the connection was created; dismiss the prompt,
+  the chat resumes automatically.
+- `warning` (`code` 503) — MCP tools couldn't load for a non-OAuth reason
+  (server unreachable / misconfigured); chat continues without those tools.
+- `error` (`status_code` 400) — OAuth timed out (default ~5 min), the auth URL
+  couldn't be built (missing `auth_{provider}` credential), or the connection
+  has no valid connected service; the user retries the message.
+
+The backend polls every ~10s and times out after ~300s. Completing OAuth *after*
+a timeout still works — the next message succeeds because the connection now
+exists.
+
 ## Notes
 
 - The connector list is paged (`page_size=12`); use `search` and `transport` to


### PR DESCRIPTION
## What

Augments the `iblai-agent-mcp` skill (`skills/iblai-agent-mcp/SKILL.md`) with MCP concepts and runtime behavior that the ibl.ai **/developer** MCP docs document but the skill was missing or covered only thinly. Additions are conceptual/behavioral only — no existing content was rewritten or reordered, and no new endpoints or request shapes were invented (the skill's own `api.iblai.app` shapes and `user|mentor|tenant` scope terms are preserved).

## What was added (three new sections before `## Notes`)

1. **Connector model** — the three cooperating objects (**MCP server** ↔ **MCP server connection** ↔ **connected service**) and how they relate, plus the `auth_type` (how: `none|token|oauth2`) vs `auth_scope`/`scope` (whose: `user|mentor|tenant`) orthogonality, and that only `oauth2` + `user` triggers the in-chat prompt. Also documents `is_featured` (lets admins in other orgs create their own connections).
2. **Runtime credential resolution** — the first-match-wins priority order (**user → mentor → tenant → featured global fallback → fail**), and that OAuth tokens auto-refresh near expiry.
3. **In-chat OAuth (per-user oauth2 connectors)** — the events emitted on the live chat socket when a per-user oauth2 connector has no connection yet: `oauth_required` (with `auth_url`), `oauth_connection_resolved`, `warning` (503), `error` (400); plus the ~10s poll interval and ~300s timeout, and that completing OAuth after a timeout still works.

## Source

Content is drawn from the ibl.ai `/developer` MCP docs:

- `docs-content/developer/agents/mcp-authentication/architecture.md`
- `docs-content/developer/agents/mcp-authentication/mcp-connections.md`
- `docs-content/developer/agents/mcp-authentication/oauth-connectors.md`
- `docs-content/developer/agents/mcp-authentication/in-chat-mcp-events.md`

Terminology was mapped to the skill's existing API vocabulary (docs `platform`→`tenant`, `agent`→`mentor`) so the skill stays internally consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)