### PR TITLE
feat(exim): add iblai-api-exim skill for data export/import

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Operate any ibl.ai organization from your AI agent. Skills + a chat MCP server.
 
-[![Skills](https://img.shields.io/badge/Skills-47-CC785C)](https://skills.sh/iblai/api)
+[![Skills](https://img.shields.io/badge/Skills-48-CC785C)](https://skills.sh/iblai/api)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-CC785C?logoColor=white)](https://claude.ai)
 [![Cursor](https://img.shields.io/badge/Cursor-000000)](https://cursor.com)
 [![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-000000?logo=githubcopilot&logoColor=white)](https://github.com/features/copilot)
@@ -104,7 +104,7 @@ After installing, use these directly in your AI agent with `/` commands.
 /iblai-api-integration     /iblai-api-notification
 /iblai-api-token          /iblai-api-invite
 /iblai-api-scim            /iblai-api-billing
-/iblai-api-feature
+/iblai-api-feature         /iblai-api-exim
 ```
 
 ### Profile
@@ -166,6 +166,7 @@ After installing, use these directly in your AI agent with `/` commands.
 | `/iblai-api-invite` | User invitations — list and send (single or CSV bulk) |
 | `/iblai-api-scim` | SCIM 2.0 directory provisioning — users (Enterprise extension), groups, departments, memberships; RBAC group assignment auto-links platforms |
 | `/iblai-api-billing` | Billing & credits — credit accounts, item paywalls, prices, checkout (auth + guest), subscriptions, access checks, revenue/subscriber reporting |
+| `/iblai-api-exim` | Export & import — start/poll whole-org migration runs, download the bundle `.zip` and upload it to another deployment; course export eligibility, Studio target environments, task queue |
 | `/iblai-api-feature` | Per-user feature config & flags — get/update (inline or feature+values), bulk-config, apps/onboarding, trial activation, platform provisioning |
 | `/iblai-api-profile` | The signed-in user's own profile — Basic, Social, Education, Experience, Resume, Memory |
 | `/iblai-api-profile-metadata` | Per-user, per-org metadata key-value store — preferences, settings, feature flags |

--- a/skills/iblai-api-exim/SKILL.md
+++ b/skills/iblai-api-exim/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: iblai-api-exim
+description: Export and import ibl.ai data via the platform API — start and poll whole-org migration runs (export a bundle, download the .zip, upload it to another deployment to import), plus course-level export eligibility, Studio target environments, and the export/import task queue. Use when moving an organization between deployments, pulling your data out as a portable bundle, or inspecting course export/import tasks.
+---
+
+# iblai-api-exim
+
+Move ibl.ai data in and out of a deployment over REST. Two independent lanes
+live under `/api/exim/manage/`:
+
+- **Platform migrations** — whole-organization export/import. Start a run, poll
+  it, download the resulting bundle `.zip`, and upload that same zip to another
+  deployment to import it. This is the "take my data with me" path.
+- **Course export/import** — per-course publishing to a Studio (CMS) target
+  environment. You declare which courses are eligible and which environments
+  they can go to; the platform queues an `EximTask` per publish and this API
+  surfaces those tasks for inspection and cancellation.
+
+## Auth & conventions
+
+- **Base URL:** `https://api.iblai.app`
+- **Header:** `Authorization: Api-Token $IBLAI_API_KEY` on every request.
+- **Prefix:** every endpoint below is a Data Manager route — call it as
+  `https://api.iblai.app/dm/api/exim/manage/…`.
+- **Permission:** every endpoint requires **DM admin** (`IsDMAdmin`). A
+  non-admin token gets `403`, not an empty list.
+- **Org scope:** migration runs identify orgs by **org key** on the wire as
+  `source_key` (export) and `target_key` (import) — the same value as
+  `$IBLAI_ORG`.
+- Not connected yet? Run **`/iblai-api-login`** first to populate `IBLAI_ORG`,
+  `IBLAI_USERNAME`, and `IBLAI_API_KEY`.
+- Destructive or outward-facing calls below (delete an environment or
+  eligibility row, cancel a run or task, start an import that writes into a
+  target org) are marked — **confirm with the user first.**
+
+## Concepts
+
+- **A run is async.** `POST …/platform-migrations/` validates, creates the row,
+  returns `201` with a `run_id`, and dispatches a Celery worker. Everything
+  after that is polling `GET …/platform-migrations/{run_id}/`.
+- **`run_id` is the lookup key**, not the surrogate PK — detail, cancel, and
+  download all take the `run_id` UUID.
+- **`status`** is one of `pending` · `in_progress` · `completed` · `failed` ·
+  `canceled`. **`phase`** is the human-readable step inside a run, and
+  **`report`** carries per-phase summaries, component selection, id-map totals,
+  and warnings once the run finishes.
+- **Components** select how much of the org travels. Mandatory sets (`core`,
+  `mentors`, `finalize`) always run; the optional sets are opt-in. Omitting
+  `selected_components` entirely means **full fidelity** (everything). See
+  [references/platform-migration.md](references/platform-migration.md).
+- **Feature-gated.** Starting a run (`POST …/platform-migrations/` or
+  `…/import-upload/`) returns `503 {"detail": "Platform migration is disabled
+  on this deployment."}` where the feature is off. Reads still work.
+- **Cancel only catches a pending run.** Once the worker flips it to
+  `in_progress`, cancel returns `409` and the run is not interrupted mid-phase.
+
+## Reads
+
+### Platform migrations
+
+- **GET** `https://api.iblai.app/dm/api/exim/manage/platform-migrations/` — list runs. Filters: `?direction=export|import`, `?status=pending|in_progress|completed|failed|canceled`, `?source_key=`, `?target_key=`. Ordering: `?ordering=` over `created_at`, `started_at`, `finished_at` (default `-created_at`).
+- **GET** `…/platform-migrations/{run_id}/` — one run: `run_id`, `direction`, `source_key`, `target_key`, `status`, `phase`, `cursor`, `selected_components`, `report`, `error_message`, `download_url`, `bundle_path`, `bundle_storage_key`, `admin_user`, `email`, `created_at`, `updated_at`, `started_at`, `finished_at`. **This is the poll endpoint.**
+- **GET** `…/platform-migrations/{run_id}/download/` — stream the bundle as a single `.zip`. Only a **completed export** is downloadable: an import returns `400`, an unfinished run `409`, and a run whose bundle is gone `404`. On an S3 deployment this `302`-redirects to a presigned URL — follow redirects (`curl -L`).
+
+> `download_url` on the run object is the same thing precomputed: a presigned S3
+> URL when the bundle lives in S3, otherwise the local download endpoint, and
+> `null` when there is nothing to pull.
+
+### Course export tasks
+
+- **GET** `…/tasks/` — list export/import tasks. Filters: `?status=`, `?target_environment={id}`, `?course__course_id=`. Ordering over `created_at`, `published_at`, `started_at`, `finished_at` (default `-created_at`).
+- **GET** `…/tasks/{id}/` — one task: `id`, `course`, `course_id`, `target_environment`, `target_environment_name`, `status`, `published_at`, `export_download_url`, `import_filename`, `error_message`, plus timestamps. **Read-only** — tasks are created by publish signals, never by this API.
+
+### Eligibility & environments
+
+- **GET** `…/eligibility/` — which courses may be exported. Filters: `?is_enabled=true|false`, `?course__course_id=`; `?search=` matches `course__course_id`.
+- **GET** `…/eligibility/{id}/` — one eligibility record: `id`, `course`, `course_id`, `is_enabled`, `target_environments`, `created_at`, `updated_at`.
+- **GET** `…/environments/` — Studio targets. Filters: `?is_enabled=true|false`; `?search=` matches `name` and `studio_base_url`.
+- **GET** `…/environments/{id}/` — one environment: `id`, `name`, `studio_base_url`, `is_enabled`, `oauth_credentials`. **`token` is write-only** and never comes back in a response.
+
+## Writes
+
+### Platform migrations
+
+- **POST** `…/platform-migrations/` — start a run. Returns `201` with the full run object (poll `run_id` from there).
+  ```json
+  {
+    "direction": "export",
+    "source_key": "$IBLAI_ORG",
+    "selected_components": ["conversations", "memory"],
+    "email": "admin@example.com"
+  }
+  ```
+  - `direction` **required** — `export` or `import`.
+  - `source_key` **required for `export`**; `target_key` **required for `import`** (validation error names the missing one).
+  - `selected_components` optional — omit for full fidelity. Unknown keys are rejected with the valid optional key list in the error.
+  - `bundle_path` optional — backfilled server-side from a deterministic root; pin it only to replay a specific bundle.
+  - `admin_user` / `email` optional — attribution and completion notice.
+  - **An import writes into the target org. Confirm with the user first.**
+- **POST** `…/platform-migrations/import-upload/` — upload a bundle `.zip` and start the import from it, in one call. `multipart/form-data`: `bundle_file` (the zip, **required**), `target_key` (**required**), optional repeatable `selected_components`, plus `admin_user`, `email`. `source_key` is read from the bundle itself. Rejects a zip with no `manifest.json` (`400` — "not a migration bundle"). **Confirm with the user first.**
+- **POST** `…/platform-migrations/{run_id}/cancel/` — cancel a **pending** run. Returns the updated run, or `409` if the worker already started it. **Confirm with the user first.**
+
+### Course export tasks
+
+- **POST** `…/tasks/{id}/cancel/` — cancel a **pending** task so the worker skips it. `409` once it is `in_progress`. **Confirm with the user first.**
+
+### Eligibility & environments
+
+- **POST** `…/eligibility/` — make a course exportable: `{"course": <id>, "is_enabled": true, "target_environments": [<env id>, …]}`. `course_id` is read-only (derived from `course`).
+- **PUT / PATCH** `…/eligibility/{id}/` — update; `PATCH` for a single field.
+- **DELETE** `…/eligibility/{id}/` — remove the eligibility record. **Confirm with the user first.**
+- **POST** `…/environments/` — register a Studio target:
+  ```json
+  {
+    "name": "Production Studio",
+    "studio_base_url": "https://studio.learn.example.com",
+    "is_enabled": true,
+    "token": "<bearer token>"
+  }
+  ```
+  `name` and `studio_base_url` are required, and you must supply **either**
+  `oauth_credentials` (an OAuth credentials id) **or** a bearer `token` —
+  neither present is a validation error.
+- **PUT / PATCH** `…/environments/{id}/` — update. Re-sending `token` replaces it; it is never readable back.
+- **DELETE** `…/environments/{id}/` — remove the target environment. **Confirm with the user first.**
+
+## Example
+
+Export the connected org, poll until it finishes, then pull the bundle:
+
+```bash
+# 1. start the export — capture the run_id
+RUN_ID=$(curl -s -X POST \
+  "https://api.iblai.app/dm/api/exim/manage/platform-migrations/" \
+  -H "Authorization: Api-Token $IBLAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"direction\":\"export\",\"source_key\":\"$IBLAI_ORG\"}" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["run_id"])')
+
+# 2. poll until status leaves pending/in_progress
+while :; do
+  STATUS=$(curl -s \
+    "https://api.iblai.app/dm/api/exim/manage/platform-migrations/$RUN_ID/" \
+    -H "Authorization: Api-Token $IBLAI_API_KEY" \
+    | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["status"], d["phase"])')
+  echo "$STATUS"
+  case "$STATUS" in pending*|in_progress*) sleep 10 ;; *) break ;; esac
+done
+
+# 3. download the bundle (-L follows the S3 presigned redirect)
+curl -sL -o bundle.zip \
+  "https://api.iblai.app/dm/api/exim/manage/platform-migrations/$RUN_ID/download/" \
+  -H "Authorization: Api-Token $IBLAI_API_KEY"
+```
+
+Then, on the destination deployment, import that same zip:
+
+```bash
+curl -X POST \
+  "https://api.iblai.app/dm/api/exim/manage/platform-migrations/import-upload/" \
+  -H "Authorization: Api-Token $IBLAI_API_KEY" \
+  -F "bundle_file=@bundle.zip" \
+  -F "target_key=$IBLAI_ORG"
+```
+
+## Notes
+
+- **Poll, don't assume.** `POST` returns `201` the moment the row commits — the
+  work has not started. A run is only finished when `status` is `completed`,
+  `failed`, or `canceled`; read `report` on success and `error_message` on
+  failure.
+- **The two lanes are unrelated.** `platform-migrations` moves a whole
+  organization between deployments. `tasks` / `eligibility` / `environments`
+  publish individual courses to a Studio CMS. Nothing in one lane affects the
+  other.
+- **Tasks are never created through this API** — they come from the course
+  publish signal and the admin sync action. `cancel` is the only write.
+- **`token` on an environment is write-only.** Reading an environment back to
+  "check" its token will always show it absent; re-send the field to rotate it.
+- **Component selection is asymmetric.** Mandatory sets run whether or not you
+  name them, so `selected_components: ["memory"]` still exports `core`,
+  `mentors`, and `finalize` — it just drops the other optional sets.
+- **Large bundles.** The download streams a zip built on demand; on multi-node
+  or S3 deployments it redirects to S3 instead, so always follow redirects and
+  write to a file rather than buffering in memory.
+
+## Reference material
+
+- [`references/platform-migration.md`](references/platform-migration.md) — the
+  run lifecycle end to end, the component registry (which data sets are
+  mandatory vs optional, and what each carries), status/phase semantics, and
+  the deployment-to-deployment handoff.

--- a/skills/iblai-api-exim/references/platform-migration.md
+++ b/skills/iblai-api-exim/references/platform-migration.md
@@ -1,0 +1,128 @@
+# Platform migration — lifecycle, components, and the deployment handoff
+
+A **platform migration** moves one organization's data out of a deployment as a
+portable bundle, and back into another deployment. It is the API behind "you own
+your data" — a run produces a `.zip` you can hold, inspect, and replay somewhere
+else. This is separate from the course export/import lane (`tasks/`,
+`eligibility/`, `environments/`), which publishes individual courses to a Studio
+CMS and shares nothing with migrations but the URL prefix.
+
+## The run lifecycle
+
+A run is a row plus a background worker. Nothing about it is synchronous.
+
+1. **Start.** `POST …/platform-migrations/` validates the request, saves the row,
+   and — only once that row commits — dispatches the Celery task. You get `201`
+   with the full run object; `run_id` (a UUID) is the handle for everything else.
+2. **Poll.** `GET …/platform-migrations/{run_id}/` returns `status` and `phase`.
+   `status` moves `pending` → `in_progress` → one of `completed` / `failed` /
+   `canceled`. `phase` names the step inside the run; `cursor` tracks progress
+   within a phase.
+3. **Finish.** On success `report` holds per-phase summaries, the resolved
+   component selection, id-map totals, and warnings. On failure read
+   `error_message`.
+4. **Collect.** For a completed **export**, `download_url` is populated and
+   `…/{run_id}/download/` streams the bundle.
+
+Lookups are by `run_id`, not by the surrogate primary key — the PK is never
+exposed.
+
+### Cancellation is a race you usually lose
+
+`POST …/{run_id}/cancel/` performs a conditional update that only matches a row
+still in `pending`. If the worker has already picked the run up, zero rows match
+and you get `409` with the current status. A run that is executing is **not**
+interrupted mid-phase — there is no way to stop it once it starts. The same
+mechanic applies to `POST …/tasks/{id}/cancel/`.
+
+### Feature gating
+
+Both start paths (`POST …/platform-migrations/` and `…/import-upload/`) check a
+deployment feature flag and return
+`503 {"detail": "Platform migration is disabled on this deployment."}` when it is
+off. Reads are never gated — you can always list and inspect existing runs.
+
+## The component registry
+
+`selected_components` chooses how much of the org travels. Components run in a
+fixed, FK-safe order; the selection cannot reorder them.
+
+| Key | Carries | Mandatory? | Phase |
+|---|---|---|---|
+| `core` | Platform + users + links | **yes** | 2 |
+| `mentors` | Agents, plus lookups, templates, settings, prompts, and M2M rows | **yes** | 3 |
+| `conversations` | Topics, sessions, messages, feedback, pins | no | 4 |
+| `memory` | Memory records and embeddings | no | 5 |
+| `training_data` | Training data, for re-training on the far side | no | 5b |
+| `blobs` | Blob bytes out of S3 | no | 6 |
+| `finalize` | Redaction, FK verification, id-map, report | **yes** | 7 |
+
+Rules that follow from that table:
+
+- **Mandatory sets always run.** Naming `["memory"]` does not mean "only memory"
+  — it means core + mentors + memory + finalize, and drops `conversations`,
+  `training_data`, and `blobs`.
+- **Omitting the field entirely means full fidelity** — every component, nothing
+  dropped. That is the right default unless you have a reason to trim.
+- **Unknown keys are rejected** at validation time, and the error lists the valid
+  optional keys.
+- Phase 1 (discover / preflight) is read-only and always runs, so it is not a
+  selectable component.
+
+Trimming is mostly about size and time: `blobs` and `memory` dominate a large
+org's bundle, and `conversations` grows without bound on a busy deployment.
+Trimming is also lossy in the obvious way — what you drop does not exist on the
+far side.
+
+## Moving a bundle between deployments
+
+The two halves of a migration run on two different deployments and are joined by
+a file you carry.
+
+**On the source deployment**
+
+1. `POST …/platform-migrations/` with `direction: "export"` and
+   `source_key: <org key>`.
+2. Poll until `status` is `completed`.
+3. `GET …/platform-migrations/{run_id}/download/` to pull the `.zip`.
+
+**On the destination deployment**
+
+4. `POST …/platform-migrations/import-upload/` as `multipart/form-data` with
+   `bundle_file` (the zip) and `target_key` (the destination org key).
+
+The upload path validates the archive before it accepts it: the zip must contain
+a `manifest.json`, or it is rejected with `400` and
+`"no manifest.json in the zip — not a migration bundle."` The **`source_key` is
+read out of the bundle**, not from your request — you only say where it is going.
+
+If you would rather not push bytes through the API, `POST
+…/platform-migrations/` with `direction: "import"` and a `bundle_path` that the
+destination can already reach does the same thing from a path on disk. The
+upload endpoint exists so a caller with nothing but API access can still complete
+the handoff.
+
+### Where the bundle actually lives
+
+- **Single-node deployment.** The bundle sits on that node's disk at
+  `bundle_path`, and `download` zips and streams it.
+- **S3 / multi-node deployment.** The bundle is written to object storage under
+  `bundle_storage_key`, and both `download_url` and the `download` endpoint hand
+  back a **presigned S3 URL** instead. `download` answers with a `302`, so any
+  client must follow redirects. The presigned URL needs no platform auth, which
+  is what makes it usable from a node that never held the file.
+
+`download_url` is `null` — and `download` refuses — in every case where there is
+nothing to fetch: the run is an import (`400`), it has not completed (`409`), or
+the bundle is no longer on disk (`404`).
+
+## Reading a finished run
+
+- `report` — the authoritative record of what happened: per-phase summaries,
+  which components were resolved as active, id-map totals, and any warnings the
+  runner raised. A run can complete *with* warnings; check them.
+- `error_message` — populated on `failed`.
+- `admin_user` / `email` — attribution captured at start; `email` is also where
+  the completion notice goes.
+- `started_at` / `finished_at` — null until the worker reaches each point, which
+  is why a `pending` run has neither.


### PR DESCRIPTION
## What

Adds `/iblai-api-exim` — a new skill covering `/api/exim/manage/`, which had **zero** coverage in this repo. Nothing here overlaps an existing skill.

Two independent lanes live under that prefix, and the skill keeps them clearly separated:

- **Platform migrations** — whole-organization export/import. Start a run, poll `status` + `phase`, download the resulting bundle `.zip`, and upload that same zip to another deployment to import it. This is the "take my data with me" path, and it's the reason this gap was worth closing: it's the API behind data ownership, and an agent couldn't drive it at all.
- **Course export/import** — per-course publishing to a Studio (CMS) target. Eligibility records, target environments, and the `EximTask` queue (read-only, plus `cancel`).

## Why this was missing

It never surfaced because it isn't in the developer docs either — it's an API-only surface. It came out of a coverage sweep comparing this repo against the platform's full route inventory.

## Sourcing

Per `CLAUDE.md` ("source of truth = the repo URLconf, not the docs"), every endpoint, request field, permission, and status code was read off **`iblai-dm-pro`** — `ibl-dm-import-export-manager/{urls.py,views.py,serializers.py}` and `platform_migration/components.py` — not from the published OpenAPI schema, which carries no request/response bodies for these routes.

That sourcing produced details the schema alone could not have:

- `IsDMAdmin` on every endpoint
- the `503` feature gate on both start paths
- the `409` cancel race (conditional UPDATE — only a `pending` run/task can be canceled; an executing run is never interrupted)
- `download`'s `400` / `409` / `404` conditions and its **`302` to a presigned S3 URL** on multi-node deployments
- `token` being **write-only** on target environments
- the "either `oauth_credentials` or `token`" validation rule
- the exact multipart fields on `import-upload/`, and that `source_key` is read **from the bundle**, not the request
- the full component registry with mandatory vs optional sets

## Structure

Follows the canonical section order from `CLAUDE.md`: `Auth & conventions` → `Concepts` → `Reads` → `Writes` → `Example` → `Notes` → `Reference material`, with resource groupings as `###` inside Reads/Writes. Every destructive or outward-facing call is marked "confirm with the user first."

`references/platform-migration.md` holds what would bloat the primary: the run lifecycle, the component registry table (which data sets are mandatory vs optional and what each carries), status/phase semantics, and the deployment-to-deployment bundle handoff including where the bundle physically lives on single-node vs S3 deployments.

## Also

- README: skills badge 47 → 48, added to the Organization group and the skill table.

## Worth a reviewer's eye

- The `Component` registry table is transcribed from `components.py`. If that registry has changed since, the table needs the same edit.
- I documented `direction: "import"` with a `bundle_path` as the alternative to `import-upload/`. That path is inferred from the serializer's validation rules rather than from an explicit code path — worth confirming it's a supported flow and not just a permissive validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)