### PR TITLE
docs(agent-memory): tenant-admin cross-user access on memsearch-settings

### DIFF
--- a/skills/iblai-api-agent-memory/SKILL.md
+++ b/skills/iblai-api-agent-memory/SKILL.md
@@ -64,7 +64,7 @@ An org-wide `enable_memsearch` flag gates the whole feature (see `memsearch-stat
 
 ### Settings
 
-- **GET** `{u}/memsearch-settings/` — the user's capture / recall settings.
+- **GET** `{u}/memsearch-settings/` — the user's capture / recall settings. Tenant admins may read another user's settings by putting that user's username in the `{username}` path segment; non-admins are restricted to their own (any other `{username}` resolves back to the caller).
 - **GET** `{u}/memsearch-status/` — whether memsearch (`enable_memsearch`) is enabled for the org.
 
 ## Writes
@@ -109,7 +109,7 @@ An org-wide `enable_memsearch` flag gates the whole feature (see `memsearch-stat
 
 ### Settings
 
-- **PUT** `{u}/memsearch-settings/` — update the user's capture / recall settings (send at least one field):
+- **PUT** `{u}/memsearch-settings/` — update the user's capture / recall settings (send at least one field). Tenant admins may update another user's settings by putting that user's username in the `{username}` path segment; non-admins are restricted to their own (any other `{username}` resolves back to the caller):
   ```json
   {
     "auto_capture_enabled": "boolean",


### PR DESCRIPTION
## Summary
- Documents that tenant admins can read/update **another** user's memory (memsearch) settings via the `{username}` path segment on `GET`/`PUT {u}/memsearch-settings/`.
- Clarifies non-admins stay pinned to their own settings — any other `{username}` resolves back to the caller.

Mirrors the backend behavior change in [iblai/iblai-platform#2382](https://github.com/iblai/iblai-platform/issues/2382) (ibl-dm-pro PR #2985).

## Test plan
- [ ] Docs-only change; verify the two `memsearch-settings` bullets in `skills/iblai-api-agent-memory/SKILL.md` render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)